### PR TITLE
OL3 basemap updates

### DIFF
--- a/basemaps.py
+++ b/basemaps.py
@@ -79,177 +79,186 @@ def basemapLeaflet():
 
 
 def basemapOL():
-    dictionary = {
-        "Stamen Watercolor": """new ol.layer.Tile({
-                                    title: 'Stamen watercolor',
-                                    source: new ol.source.Stamen({
-                                        layer: 'watercolor'
-                                    })
-                                })""",
-        "Stamen Toner": """new ol.layer.Tile({title: 'Stamen toner',
-                                              source: new ol.source.Stamen({
-                                                layer: 'toner'
-                                              })
-                                            })""",
-        "Stamen Terrain": """new ol.layer.Tile({title: 'Stamen terrain',
-                                                source: new ol.source.Stamen({
-                                                    layer: 'terrain'
-                                                })
-                                              })""",
-        "OSM Standard": """new ol.layer.Tile({title: 'OSM',
-                                              source: new ol.source.OSM()
-                                            })""",
-        "MapQuestOpen OSM": """new ol.layer.Tile({
-                                    title: 'MapQuest OSM',
-                                    source: new ol.source.MapQuest({
-                                        layer: 'osm'
-                                    })
-                               })""",
-        "MapQuestOpen Aerial": """new ol.layer.Tile({
-                                    title: 'MapQuest Aerial',
-                                    source: new ol.source.MapQuest({
-                                        layer: 'sat'
-                                    })
-                                  })""",
-        "Thunderforest Transport": """
-new ol.layer.Tile({
-    title: 'Thunderforest Transport',
-    source: new ol.source.XYZ({
-        url: 'http://tile.thunderforest.com/transport/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['Thunderforest Transport'],
-        "Thunderforest Landscape": """
-new ol.layer.Tile({
-    title: 'Thunderforest Landscape',
-    source: new ol.source.XYZ({
-        url: 'http://tile.thunderforest.com/landscape/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['Thunderforest Landscape'],
-        "Thunderforest Outdoors": """
-new ol.layer.Tile({
-    title: 'Thunderforest Outdoors',
-    source: new ol.source.XYZ({
-        url: 'http://tile.thunderforest.com/outdoors/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['Thunderforest Outdoors'],
-        "OpenMapSurfer Roads": """
-new ol.layer.Tile({
-    title: 'OpenMapSurfer Roads',
-    source: new ol.source.XYZ({
-        url: 'http://openmapsurfer.uni-hd.de/tiles/roads/x={x}&y={y}&z={z}',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OpenMapSurfer Roads'],
-        "OpenMapSurfer adminb": """
-new ol.layer.Tile({
-    title: 'OpenMapSurfer adminb',
-    source: new ol.source.XYZ({
-        url: 'http://openmapsurfer.uni-hd.de/tiles/adminb/x={x}&y={y}&z={z}',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OpenMapSurfer adminb'],
-        "OpenMapSurfer roadsg": """
-new ol.layer.Tile({
-    title: 'OpenMapSurfer roadsg',
-    source: new ol.source.XYZ({
-        url: 'http://openmapsurfer.uni-hd.de/tiles/roadsg/x={x}&y={y}&z={z}',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OpenMapSurfer roadsg'],
-        "OSM HOT": """
-new ol.layer.Tile({
-    title: 'OSM HOT',
-    source: new ol.source.XYZ({
-        url: 'http://{a-c}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OSM HOT'],
-        "OpenSeaMap": """
-new ol.layer.Tile({
-    title: 'OpenSeaMap',
-    source: new ol.source.XYZ({
-        url: 'http://t1.openseamap.org/seamark/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OpenSeaMap'],
-        "Thunderforest Cycle": """
-new ol.layer.Tile({
-    title: 'Thunderforest Cycle',
-    source: new ol.source.XYZ({
-        url: 'http://tile.thunderforest.com/cycle/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['Thunderforest Cycle'],
-        "OSM DE": """
-new ol.layer.Tile({
-    title: 'OSM DE',
-    source: new ol.source.XYZ({
-        url: 'http://tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OSM DE'],
-        "OpenWeatherMap Clouds": """
-new ol.layer.Tile({
-    title: 'OpenWeatherMap Clouds',
-    source: new ol.source.XYZ({
-        url: 'http://tile.openweathermap.org/map/clouds/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OpenWeatherMap Clouds'],
-        "OpenWeatherMap Precipitation": """
-new ol.layer.Tile({
-    title: 'OpenWeatherMap Precipitation',
-    source: new ol.source.XYZ({
-        url:'http://tile.openweathermap.org/map/precipitation/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OpenWeatherMap Precipitation'],
-        "OpenWeatherMap Rain": """
-new ol.layer.Tile({
-    title: 'OpenWeatherMap Rain',
-    source: new ol.source.XYZ({
-        url: 'http://tile.openweathermap.org/map/rain/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OpenWeatherMap Rain'],
-        "OpenWeatherMap Pressure": """
-new ol.layer.Tile({
-    title: 'OpenWeatherMap Pressure',
-    source: new ol.source.XYZ({
-        url: 'http://tile.openweathermap.org/map/pressure/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OpenWeatherMap Pressure'],
-        "OpenWeatherMap Wind": """
-new ol.layer.Tile({
-    title: 'OpenWeatherMap Wind',
-    source: new ol.source.XYZ({
-        url: 'http://tile.openweathermap.org/map/wind/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OpenWeatherMap Wind'],
-        "OpenWeatherMap Temp": """
-new ol.layer.Tile({
-    title: 'OpenWeatherMap Temp',
-    source: new ol.source.XYZ({
-        url: 'http://tile.openweathermap.org/map/temp/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OpenWeatherMap Temp'],
-        "OpenWeatherMap Snow": """
-new ol.layer.Tile({
-    title: 'OpenWeatherMap Snow',
-    source: new ol.source.XYZ({
-        url: 'http://tile.openweathermap.org/map/snow/{z}/{x}/{y}.png',
-        attributions: [new ol.Attribution({html:'%s'})]
-    })
-})""" % basemapAttributions()['OpenWeatherMap Snow']
+    basemaps = {
+        "Stamen Watercolor": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.Stamen({{
+                layer: 'watercolor'
+            }})
+        }})""",
+        "Stamen Toner": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+                source: new ol.source.Stamen({{
+                layer: 'toner'
+                }})
+        }})""",
+        "Stamen Terrain": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.Stamen({{
+                layer: 'terrain'
+            }})
+        }})""",
+        "OSM": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.OSM()
+        }})""",
+        "MapQuest OSM": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.MapQuest({{
+                layer: 'osm'
+            }})
+        }})""",
+        "MapQuest Aerial": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.MapQuest({{
+                layer: 'sat'
+            }})
+        }})""",
+        "Thunderforest Transport": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://tile.thunderforest.com/transport/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "Thunderforest Landscape": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://tile.thunderforest.com/landscape/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "Thunderforest Outdoors": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://tile.thunderforest.com/outdoors/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OpenMapSurfer Roads": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://openmapsurfer.uni-hd.de/tiles/roads/x={{x}}&y={{y}}&z={{z}}',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OpenMapSurfer adminb": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://openmapsurfer.uni-hd.de/tiles/adminb/x={{x}}&y={{y}}&z={{z}}',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OpenMapSurfer roadsg": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://openmapsurfer.uni-hd.de/tiles/roadsg/x={{x}}&y={{y}}&z={{z}}',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OSM HOT": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://{{a-c}}.tile.openstreetmap.fr/hot/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OpenSeaMap": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://t1.openseamap.org/seamark/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "Thunderforest Cycle": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://tile.thunderforest.com/cycle/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OSM DE": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://tile.openstreetmap.de/tiles/osmde/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OpenWeatherMap Clouds": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://tile.openweathermap.org/map/clouds/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OpenWeatherMap Precipitation": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url:'http://tile.openweathermap.org/map/precipitation/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OpenWeatherMap Rain": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://tile.openweathermap.org/map/rain/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OpenWeatherMap Pressure": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://tile.openweathermap.org/map/pressure/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OpenWeatherMap Wind": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://tile.openweathermap.org/map/wind/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OpenWeatherMap Temp": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://tile.openweathermap.org/map/temp/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})""",
+        "OpenWeatherMap Snow": """new ol.layer.Tile({{
+            'title': '{title}',
+            'type': 'base',
+            source: new ol.source.XYZ({{
+                url: 'http://tile.openweathermap.org/map/snow/{{z}}/{{x}}/{{y}}.png',
+                attributions: [new ol.Attribution({{html: '{attr}'}})]
+            }})
+        }})"""
     }
-    return dictionary
-
+    basemaps = {k: v.format(**{'title': k, 'attr': basemapAttributions[k]}) for k, v in basemaps.iteritems()}
+    return basemaps
 
 basemapAttributions = {
     'OSM': """\

--- a/basemaps.py
+++ b/basemaps.py
@@ -53,9 +53,9 @@ def basemapLeaflet():
         'OpenMapSurfer roadsg': ('http://openmapsurfer.uni-hd.de/tiles/' +
                                  'roadsg/x={x}&y={y}&z={z}'),
         'MapQuest OSM': ('http://otile1.mqcdn.com/tiles/1.0.0/map/' +
-                             '{z}/{x}/{y}.jpeg'),
+                         '{z}/{x}/{y}.jpeg'),
         'MapQuest Aerial': ('http://otile1.mqcdn.com/tiles/1.0.0/sat/' +
-                                '{z}/{x}/{y}.jpg'),
+                            '{z}/{x}/{y}.jpg'),
         'Stamen Terrain': 'http://a.tile.stamen.com/terrain/{z}/{x}/{y}.png',
         'Stamen Watercolor': ('http://a.tile.stamen.com/watercolor/' +
                               '{z}/{x}/{y}.png'),

--- a/basemaps.py
+++ b/basemaps.py
@@ -80,184 +80,212 @@ def basemapLeaflet():
 
 def basemapOL():
     basemaps = {
-        "Stamen Watercolor": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.Stamen({{
-                layer: 'watercolor'
-            }})
-        }})""",
-        "Stamen Toner": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-                source: new ol.source.Stamen({{
-                layer: 'toner'
-                }})
-        }})""",
-        "Stamen Terrain": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.Stamen({{
-                layer: 'terrain'
-            }})
-        }})""",
-        "OSM": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.OSM()
-        }})""",
-        "MapQuest OSM": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.MapQuest({{
-                layer: 'osm'
-            }})
-        }})""",
-        "MapQuest Aerial": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.MapQuest({{
-                layer: 'sat'
-            }})
-        }})""",
-        "Thunderforest Transport": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://tile.thunderforest.com/transport/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "Thunderforest Landscape": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://tile.thunderforest.com/landscape/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "Thunderforest Outdoors": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://tile.thunderforest.com/outdoors/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OpenMapSurfer Roads": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://openmapsurfer.uni-hd.de/tiles/roads/x={{x}}&y={{y}}&z={{z}}',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OpenMapSurfer adminb": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://openmapsurfer.uni-hd.de/tiles/adminb/x={{x}}&y={{y}}&z={{z}}',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OpenMapSurfer roadsg": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://openmapsurfer.uni-hd.de/tiles/roadsg/x={{x}}&y={{y}}&z={{z}}',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OSM HOT": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://{{a-c}}.tile.openstreetmap.fr/hot/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OpenSeaMap": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://t1.openseamap.org/seamark/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "Thunderforest Cycle": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://tile.thunderforest.com/cycle/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OSM DE": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://tile.openstreetmap.de/tiles/osmde/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OpenWeatherMap Clouds": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://tile.openweathermap.org/map/clouds/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OpenWeatherMap Precipitation": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url:'http://tile.openweathermap.org/map/precipitation/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OpenWeatherMap Rain": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://tile.openweathermap.org/map/rain/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OpenWeatherMap Pressure": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://tile.openweathermap.org/map/pressure/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OpenWeatherMap Wind": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://tile.openweathermap.org/map/wind/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OpenWeatherMap Temp": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://tile.openweathermap.org/map/temp/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})""",
-        "OpenWeatherMap Snow": """new ol.layer.Tile({{
-            'title': '{title}',
-            'type': 'base',
-            source: new ol.source.XYZ({{
-                url: 'http://tile.openweathermap.org/map/snow/{{z}}/{{x}}/{{y}}.png',
-                attributions: [new ol.Attribution({{html: '{attr}'}})]
-            }})
-        }})"""
+        "Stamen Watercolor": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.Stamen({{
+        layer: 'watercolor'
+    }})
+}})""",
+        "Stamen Toner": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+        source: new ol.source.Stamen({{
+        layer: 'toner'
+        }})
+}})""",
+        "Stamen Terrain": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.Stamen({{
+        layer: 'terrain'
+    }})
+}})""",
+        "OSM": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.OSM()
+}})""",
+        "MapQuest OSM": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.MapQuest({{
+        layer: 'osm'
+    }})
+}})""",
+        "MapQuest Aerial": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.MapQuest({{
+        layer: 'sat'
+    }})
+}})""",
+        "Thunderforest Transport": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://tile.thunderforest.com/transport/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "Thunderforest Landscape": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://tile.thunderforest.com/landscape/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "Thunderforest Outdoors": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://tile.thunderforest.com/outdoors/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OpenMapSurfer Roads": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: \
+'http://openmapsurfer.uni-hd.de/tiles/roads/x={{x}}&y={{y}}&z={{z}}',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OpenMapSurfer adminb": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: \
+'http://openmapsurfer.uni-hd.de/tiles/adminb/x={{x}}&y={{y}}&z={{z}}',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OpenMapSurfer roadsg": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: \
+'http://openmapsurfer.uni-hd.de/tiles/roadsg/x={{x}}&y={{y}}&z={{z}}',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OSM HOT": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://{{a-c}}.tile.openstreetmap.fr/hot/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OpenSeaMap": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://t1.openseamap.org/seamark/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "Thunderforest Cycle": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://tile.thunderforest.com/cycle/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OSM DE": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://tile.openstreetmap.de/tiles/osmde/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OpenWeatherMap Clouds": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://tile.openweathermap.org/map/clouds/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OpenWeatherMap Precipitation": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url:'http://tile.openweathermap.org/map/precipitation/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OpenWeatherMap Rain": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://tile.openweathermap.org/map/rain/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OpenWeatherMap Pressure": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: \
+'http://tile.openweathermap.org/map/pressure/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OpenWeatherMap Wind": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://tile.openweathermap.org/map/wind/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OpenWeatherMap Temp": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://tile.openweathermap.org/map/temp/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})""",
+        "OpenWeatherMap Snow": """
+new ol.layer.Tile({{
+    'title': '{title}',
+    'type': 'base',
+    source: new ol.source.XYZ({{
+        url: 'http://tile.openweathermap.org/map/snow/{{z}}/{{x}}/{{y}}.png',
+        attributions: [new ol.Attribution({{html: '{attr}'}})]
+    }})
+}})"""
     }
-    basemaps = {k: v.format(**{'title': k, 'attr': basemapAttributions[k]}) for k, v in basemaps.iteritems()}
+    basemaps = {k: v.format(**{'title': k, 'attr': basemapAttributions[k]})
+                for k, v in basemaps.iteritems()}
     return basemaps
 
 basemapAttributions = {

--- a/basemaps.py
+++ b/basemaps.py
@@ -33,7 +33,7 @@ INSTRUCTION ON FILE USAGE:
 
 def basemapLeaflet():
     dictionary = {
-        'OSM Standard': 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        'OSM': 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
         'Stamen Toner': 'http://a.tile.stamen.com/toner/{z}/{x}/{y}.png',
         'OSM DE': ('http://{s}.tile.openstreetmap.de/tiles/' +
                    'osmde/{z}/{x}/{y}.png'),
@@ -52,9 +52,9 @@ def basemapLeaflet():
                                  'adminb/x={x}&y={y}&z={z}'),
         'OpenMapSurfer roadsg': ('http://openmapsurfer.uni-hd.de/tiles/' +
                                  'roadsg/x={x}&y={y}&z={z}'),
-        'MapQuestOpen OSM': ('http://otile1.mqcdn.com/tiles/1.0.0/map/' +
+        'MapQuest OSM': ('http://otile1.mqcdn.com/tiles/1.0.0/map/' +
                              '{z}/{x}/{y}.jpeg'),
-        'MapQuestOpen Aerial': ('http://otile1.mqcdn.com/tiles/1.0.0/sat/' +
+        'MapQuest Aerial': ('http://otile1.mqcdn.com/tiles/1.0.0/sat/' +
                                 '{z}/{x}/{y}.jpg'),
         'Stamen Terrain': 'http://a.tile.stamen.com/terrain/{z}/{x}/{y}.png',
         'Stamen Watercolor': ('http://a.tile.stamen.com/watercolor/' +
@@ -251,93 +251,91 @@ new ol.layer.Tile({
     return dictionary
 
 
-def basemapAttributions():
-    dictionary = {
-        'OSM Standard': """\
+basemapAttributions = {
+    'OSM': """\
 &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors,\
 <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>""",
-        'Stamen Toner': """\
+    'Stamen Toner': """\
 Map tiles by <a href="http://stamen.com">Stamen Design</a>,\
 <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map\
 data: &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>\
 contributors,\
 <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>""",
-        'OSM DE': """\
+    'OSM DE': """\
 &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors,\
 <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>""",
-        'OSM HOT': """\
+    'OSM HOT': """\
 &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors,\
 <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>,\
 Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">\
 Humanitarian OpenStreetMap Team</a>""",
-        'OpenSeaMap': """\
+    'OpenSeaMap': """\
 Map data: &copy; <a href="http://www.openseamap.org">OpenSeaMap</a>\
 contributors""",
-        'Thunderforest Cycle': """\
+    'Thunderforest Cycle': """\
 &copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>,\
 &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors,\
 <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>""",
-        'Thunderforest Transport': """\
+    'Thunderforest Transport': """\
 &copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>,\
 &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors,\
 <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>""",
-        'Thunderforest Landscape': """\
+    'Thunderforest Landscape': """\
 &copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>,\
 &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors,\
 <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>""",
-        'Thunderforest Outdoors': """\
+    'Thunderforest Outdoors': """\
 &copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>,\
 &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors,\
 <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>""",
-        'OpenMapSurfer Roads': """\
+    'OpenMapSurfer Roads': """\
 Imagery from <a href="http://giscience.uni-hd.de/">GIScience Research Group @\
 University of Heidelberg</a> &mdash; Map data:\
 &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors,\
 <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>""",
-        'OpenMapSurfer adminb': """\
+    'OpenMapSurfer adminb': """\
 Imagery from <a href="http://giscience.uni-hd.de/">GIScience Research Group @\
 University of Heidelberg</a> &mdash; Map data:\
 &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors,\
 <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>""",
-        'OpenMapSurfer roadsg': """\
+    'OpenMapSurfer roadsg': """\
 Imagery from <a href="http://giscience.uni-hd.de/">GIScience Research Group @\
 University of Heidelberg</a> &mdash; Map data:\
 &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors,\
 <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>""",
-        'MapQuestOpen OSM': """\
+    'MapQuest OSM': """\
 Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a> &mdash;\
 Map data: &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>\
 contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">\
 CC-BY-SA</a>""",
-        'MapQuestOpen Aerial': """\
+    'MapQuest Aerial': """\
 Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a> &mdash;\
 Portions Courtesy NASA/JPL-Caltech and U.S. Depart. of Agriculture,\
 Farm Service Agency""",
-        'Stamen Terrain': """\
+    'Stamen Terrain': """\
 Map tiles by <a href="http://stamen.com">Stamen Design</a>,\
 <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash;\
 Map data: &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>\
 contributors,<a href="http://creativecommons.org/licenses/by-sa/2.0/">\
 CC-BY-SA</a>""",
-        'Stamen Watercolor': """\
+    'Stamen Watercolor': """\
 Map tiles by <a href="http://stamen.com">Stamen Design</a>,\
 <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash;\
 Map data: &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>\
 contributors,<a href="http://creativecommons.org/licenses/by-sa/2.0/">\
 CC-BY-SA</a>""",
-        'OpenWeatherMap Clouds': """\
+    'OpenWeatherMap Clouds': """\
 Map data &copy; <a href="http://openweathermap.org">OpenWeatherMap</a>""",
-        'OpenWeatherMap Precipitation': """\
+    'OpenWeatherMap Precipitation': """\
 Map data &copy; <a href="http://openweathermap.org">OpenWeatherMap</a>""",
-        'OpenWeatherMap Rain': """\
+    'OpenWeatherMap Rain': """\
 Map data &copy; <a href="http://openweathermap.org">OpenWeatherMap</a>""",
-        'OpenWeatherMap Pressure': """\
+    'OpenWeatherMap Pressure': """\
 Map data &copy; <a href="http://openweathermap.org">OpenWeatherMap</a>""",
-        'OpenWeatherMap Wind': """\
+    'OpenWeatherMap Wind': """\
 Map data &copy; <a href="http://openweathermap.org">OpenWeatherMap</a>""",
-        'OpenWeatherMap Temp': """\
+    'OpenWeatherMap Temp': """\
 Map data &copy; <a href="http://openweathermap.org">OpenWeatherMap</a>""",
-        'OpenWeatherMap Snow': """\
+    'OpenWeatherMap Snow': """\
 Map data &copy; <a href="http://openweathermap.org">OpenWeatherMap</a>"""
-    }
-    return dictionary
+}

--- a/configparams.py
+++ b/configparams.py
@@ -59,7 +59,7 @@ paramsOL = {
 }
 
 baselayers = (
-            "OSM Standard",
+            "OSM",
             "Stamen Toner",
             "OSM DE",
             "OSM HOT",
@@ -70,8 +70,8 @@ baselayers = (
             "OpenMapSurfer Roads",
             "OpenMapSurfer adminb",
             "OpenMapSurfer roadsg",
-            "MapQuestOpen OSM",
-            "MapQuestOpen Aerial",
+            "MapQuest OSM",
+            "MapQuest Aerial",
             "Stamen Terrain",
             "Stamen Watercolor",
             "OpenWeatherMap Clouds",

--- a/leafletScriptStrings.py
+++ b/leafletScriptStrings.py
@@ -8,7 +8,6 @@ from utils import scaleToZoom
 from basemaps import basemapLeaflet, basemapAttributions
 
 basemapAddresses = basemapLeaflet()
-basemapAttributions = basemapAttributions()
 
 
 def jsonScript(layer):

--- a/leafletWriter.py
+++ b/leafletWriter.py
@@ -26,7 +26,7 @@ import qgis.utils
 import os
 import time
 import re
-from basemaps import basemapLeaflet, basemapAttributions
+from basemaps import basemapLeaflet
 from leafletFileScripts import *
 from leafletLayerScripts import *
 from leafletScriptStrings import *

--- a/olwriter.py
+++ b/olwriter.py
@@ -29,10 +29,9 @@ from PyQt4.QtCore import *
 from PyQt4.QtGui import *
 from olScriptStrings import *
 from utils import ALL_ATTRIBUTES
-from basemaps import basemapOL, basemapAttributions
+from basemaps import basemapOL
 
 baseLayers = basemapOL()
-basemapAttributions = basemapAttributions()
 
 baseLayerGroup = "var baseLayer = "
 baseLayerGroup += "new ol.layer.Group({'title': 'Base maps',layers: [%s]});"

--- a/olwriter.py
+++ b/olwriter.py
@@ -31,6 +31,7 @@ from olScriptStrings import *
 from utils import ALL_ATTRIBUTES
 from basemaps import basemapOL
 
+
 def writeOL(iface, layers, groups, popup, visible,
             json, clustered, settings, folder):
     QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
@@ -225,12 +226,12 @@ def writeLayersAndGroups(layers, groups, visible, folder,
 
     canvas = iface.mapCanvas()
     basemapList = settings["Appearance"]["Base layer"]
-    basemaps = ','.join([basemapOL()[item.text()] for _, item in enumerate(basemapList)])
+    basemaps = [basemapOL()[item.text()] for _, item in enumerate(basemapList)]
 
     baseLayer = """var baseLayer = new ol.layer.Group({
     'title': 'Base maps',
     layers: [%s\n]
-});""" % basemaps
+});""" % ','.join(basemaps)
 
     layerVars = ""
     for layer, encode2json, cluster in zip(layers, json, clustered):


### PR DESCRIPTION
@tomchadwin this PR addresses #219 and ensures the base maps group is only added when at least one base map is selected. I've added a couple of tests to cover the changes.

I've also made some small changes to how the OL3 base maps are defined in `basemaps.py`: to try and reduce duplication I'm using the key in the dict as the layer title and substituting the attribution in a  dictionary comprehension once all base maps have been defined.