### PR TITLE
Fix log spamming resulting from invalid config options

### DIFF
--- a/leafletLayerScripts.py
+++ b/leafletLayerScripts.py
@@ -69,12 +69,11 @@ def exportJSONLayer(layer, eachPopup, precision, tmpFileName, exp_crs,
         renderer.stopRender(renderContext)
 
     writer = QgsVectorFileWriter
+    options = []
     if precision != "maintain":
-        options = "COORDINATE_PRECISION=" + unicode(precision)
-    else:
-        options = ""
+        options.append("COORDINATE_PRECISION=" + unicode(precision))
     writer.writeAsVectorFormat(cleanedLayer, tmpFileName, 'utf-8', exp_crs,
-                               'GeoJson', 0, layerOptions=[options])
+                               'GeoJson', 0, layerOptions=options)
 
     with open(layerFileName, "w") as f2:
         f2.write("var json_" + unicode(safeLayerName) + "=")

--- a/utils.py
+++ b/utils.py
@@ -214,14 +214,13 @@ def exportLayers(iface, layers, folder, precision, optimize,
             sln = safeName(cleanLayer.name()) + unicode(count)
             tmpPath = os.path.join(layersFolder, sln + ".json")
             path = os.path.join(layersFolder, sln + ".js")
+            options = []
             if precision != "maintain":
-                options = "COORDINATE_PRECISION=" + unicode(precision)
-            else:
-                options = ""
+                options.append("COORDINATE_PRECISION=" + unicode(precision))
             QgsVectorFileWriter.writeAsVectorFormat(cleanLayer, tmpPath,
                                                     "utf-8", epsg4326,
                                                     'GeoJson', 0,
-                                                    layerOptions=[options])
+                                                    layerOptions=options)
             with open(path, "w") as f:
                 f.write("var %s = " % ("geojson_" + sln))
                 with open(tmpPath, "r") as f2:


### PR DESCRIPTION
Avoids a bunch of warnings from GDAL about config options not following key=value pattern.