### PR TITLE
Fixes for FTP upload

### DIFF
--- a/test/test_qgis2web_dialog.py
+++ b/test/test_qgis2web_dialog.py
@@ -30,7 +30,6 @@ from utilities import get_qgis_app, test_data_path, load_layer, load_wfs_layer
 
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 
-from test_qgis2web_exporters import qgis2web_exporterTest
 from maindialog import MainDialog
 
 
@@ -2364,6 +2363,5 @@ def diff(control_output, test_output):
 if __name__ == "__main__":
     suite = unittest.TestSuite()
     suite.addTests(unittest.makeSuite(qgis2web_classDialogTest))
-    suite.addTests(unittest.makeSuite(qgis2web_exporterTest))
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)

--- a/test/test_qgis2web_exporters.py
+++ b/test/test_qgis2web_exporters.py
@@ -243,6 +243,42 @@ class qgis2web_exporterTest(unittest.TestCase):
         content = open(expected_index_file,'r').readlines()
         self.assertEqual(content,['test2'])
 
+    def test10_FtpUploadSubfolder(self):
+        e = FtpExporter()
+        e.host = 'localhost'
+        e.port = TEST_PORT
+        e.username = 'testuser'
+        e.password = 'pw'
+
+        # copy some files to export directory
+        export_folder = e.exportDirectory()
+        try:
+            os.makedirs(export_folder)
+        except:
+            self.assertTrue(False, 'could not create export directory')
+        out_file = os.path.join(export_folder,'index.html')
+        with open(out_file,'w') as i:
+            i.write('test')
+        sub_folder=os.path.join(export_folder,'sub')
+        try:
+            os.makedirs(sub_folder)
+        except:
+            self.assertTrue(False, 'could not create export directory')
+        sub_folder_out_file = os.path.join(sub_folder,'index.html')
+        with open(sub_folder_out_file,'w') as i:
+            i.write('test2')
+
+        e.postProcess(out_file)
+
+        expected_index_file = os.path.join(FTP_USER_FOLDER,'public_html','index.html')
+        self.assertTrue(os.path.exists(expected_index_file))
+        content = open(expected_index_file,'r').readlines()
+        self.assertEqual(content,['test'])
+        expected_sub_folder_index_file = os.path.join(FTP_USER_FOLDER, 'public_html', 'sub', 'index.html')
+        self.assertTrue(os.path.exists(expected_sub_folder_index_file))
+        content = open(expected_sub_folder_index_file, 'r').readlines()
+        self.assertEqual(content, ['test2'])
+
 
 
 


### PR DESCRIPTION
- Create path if missing on FTP site
- Add unit checks for upload and overwriting existing files

On behalf of Faunalia, sponsored by ENEL