### PR TITLE
Refactor writers

### DIFF
--- a/leafletScriptStrings.py
+++ b/leafletScriptStrings.py
@@ -143,8 +143,8 @@ def featureGroupsScript():
 def basemapsScript(basemapList, maxZoom):
     basemaps = ""
     for count, basemap in enumerate(basemapList):
-        bmText = basemapAddresses[basemap.text()]
-        bmAttr = basemapAttributions[basemap.text()]
+        bmText = basemapAddresses[basemap]
+        bmAttr = basemapAttributions[basemap]
         basemaps += """
         var basemap{count} = L.tileLayer('{basemap}', {{
             attribution: '{attribution}',
@@ -378,7 +378,7 @@ def addLayersList(basemapList, matchCRS, layer_list, cluster, legends):
         controlStart = """
         var baseMaps = {"""
         for count, basemap in enumerate(basemapList):
-            controlStart += comma + "'" + unicode(basemap.text())
+            controlStart += comma + "'" + unicode(basemap)
             controlStart += "': basemap" + unicode(count)
             comma = ", "
         controlStart += "};"

--- a/leafletWriter.py
+++ b/leafletWriter.py
@@ -56,14 +56,13 @@ class LeafletWriter(Writer):
     def name(cls):
         return QObject.tr(translator, 'Leaflet')
 
-    def write(self, iface, groups, layers, visible,
-              cluster, popup, json, params, dest_folder):
-        self.preview_file = self.writeLeaflet(iface, layer_list=layers,
-                                              popup=popup,
-                                              visible=visible,
-                                              json=json,
-                                              cluster=cluster,
-                                              params=params,
+    def write(self, iface, dest_folder):
+        self.preview_file = self.writeLeaflet(iface, layer_list=self.layers,
+                                              popup=self.popup,
+                                              visible=self.visible,
+                                              json=self.json,
+                                              cluster=self.cluster,
+                                              params=self.params,
                                               folder=dest_folder)
         return self.preview_file
 

--- a/leafletWriter.py
+++ b/leafletWriter.py
@@ -35,7 +35,8 @@ from leafletLayerScripts import *
 from leafletScriptStrings import *
 from utils import ALL_ATTRIBUTES, PLACEMENT, removeSpaces
 from writer import (Writer,
-    translator)
+                    translator)
+
 
 class LeafletWriter(Writer):
     """
@@ -55,8 +56,10 @@ class LeafletWriter(Writer):
         return QObject.tr(translator, 'Leaflet')
 
     @classmethod
-    def writeLeaflet(cls, iface, outputProjectFileName, layer_list, visible, cluster,
-                     json, params, popup):
+    def writeLeaflet(
+            cls, iface, outputProjectFileName,
+            layer_list, visible, cluster,
+            json, params, popup):
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         legends = {}
         canvas = iface.mapCanvas()
@@ -91,9 +94,11 @@ class LeafletWriter(Writer):
         QgsApplication.initQgis()
 
         dataStore, cssStore = writeFoldersAndFiles(pluginDir,
-                                                   outputProjectFileName, cluster,
-                                                   measure, matchCRS, layerSearch,
-                                                   canvas, mapLibLocation, locate)
+                                                   outputProjectFileName,
+                                                   cluster, measure,
+                                                   matchCRS, layerSearch,
+                                                   canvas, mapLibLocation,
+                                                   locate)
         writeCSS(cssStore, mapSettings.backgroundColor().name())
 
         wfsLayers = ""
@@ -105,7 +110,8 @@ class LeafletWriter(Writer):
         lyrCount = 0
         for layer, jsonEncode, eachPopup in zip(layer_list, json, popup):
             rawLayerName = layer.name()
-            safeLayerName = re.sub('[\W_]+', '', rawLayerName) + unicode(lyrCount)
+            safeLayerName = re.sub(
+                '[\W_]+', '', rawLayerName) + unicode(lyrCount)
             lyrCount += 1
             dataPath = os.path.join(dataStore, safeLayerName)
             tmpFileName = dataPath + '.json'
@@ -113,19 +119,20 @@ class LeafletWriter(Writer):
             if layer.providerType() != 'WFS' or jsonEncode is True and layer:
                 if layer.type() == QgsMapLayer.VectorLayer:
                     exportJSONLayer(layer, eachPopup, precision, tmpFileName,
-                                    exp_crs, layerFileName, safeLayerName, minify,
-                                    canvas, restrictToExtent, iface, extent)
+                                    exp_crs, layerFileName,
+                                    safeLayerName, minify, canvas,
+                                    restrictToExtent, iface, extent)
                     new_src += jsonScript(safeLayerName)
-                    scaleDependentLayers = scaleDependentLabelScript(layer,
-                                                                     safeLayerName)
+                    scaleDependentLayers =\
+                        scaleDependentLabelScript(layer, safeLayerName)
                     labelVisibility += scaleDependentLayers
 
                 elif layer.type() == QgsMapLayer.RasterLayer:
                     if layer.dataProvider().name() != "wms":
                         exportRasterLayer(layer, safeLayerName, dataPath)
             if layer.hasScaleBasedVisibility():
-                scaleDependentLayers += scaleDependentLayerScript(layer,
-                                                                  safeLayerName)
+                scaleDependentLayers += scaleDependentLayerScript(
+                    layer, safeLayerName)
         if scaleDependentLayers != "":
             scaleDependentLayers = scaleDependentScript(scaleDependentLayers)
 
@@ -177,9 +184,10 @@ class LeafletWriter(Writer):
                  wfsLayers) = writeVectorLayer(layer, safeLayerName,
                                                usedFields[count], highlight,
                                                popupsOnHover, popup[count],
-                                               outputProjectFileName, wfsLayers,
-                                               cluster[count], visible[count],
-                                               json[count], legends, new_src,
+                                               outputProjectFileName,
+                                               wfsLayers, cluster[count],
+                                               visible[count], json[count],
+                                               legends, new_src,
                                                canvas, count, restrictToExtent,
                                                extent)
             elif layer.type() == QgsMapLayer.RasterLayer:
@@ -200,8 +208,9 @@ class LeafletWriter(Writer):
             new_src += address_text
 
         if params["Appearance"]["Add layers list"]:
-            new_src += addLayersList(basemapList, matchCRS, layer_list, cluster,
-                                     legends)
+            new_src += addLayersList(
+                basemapList, matchCRS, layer_list, cluster,
+                legends)
         if project.readBoolEntry("ScaleBar", "/Enabled", False)[0]:
             placement = project.readNumEntry("ScaleBar", "/Placement", 0)[0]
             placement = PLACEMENT[placement]
@@ -209,12 +218,13 @@ class LeafletWriter(Writer):
         else:
             end = ''
         searchLayer = "layer_%s" % params["Appearance"]["Search layer"]
-        end += endHTMLscript(wfsLayers, layerSearch, labelVisibility, searchLayer)
+        end += endHTMLscript(
+            wfsLayers, layerSearch, labelVisibility, searchLayer)
         new_src += end
         try:
-            writeHTMLstart(outputIndex, title, cluster, addressSearch, measure,
-                           matchCRS, layerSearch, canvas, mapLibLocation, locate,
-                           new_src, template)
+            writeHTMLstart(outputIndex, title, cluster, addressSearch,
+                           measure, matchCRS, layerSearch, canvas,
+                           mapLibLocation, locate, new_src, template)
         except:
             pass
         finally:

--- a/leafletWriter.py
+++ b/leafletWriter.py
@@ -39,6 +39,7 @@ from writer import (Writer,
 
 
 class LeafletWriter(Writer):
+
     """
     Writer for creation of web maps based on the Leaflet
     JavaScript library.
@@ -55,11 +56,23 @@ class LeafletWriter(Writer):
     def name(cls):
         return QObject.tr(translator, 'Leaflet')
 
+    def write(self, iface, groups, layers, visible,
+              cluster, popup, json, params, dest_folder):
+        self.preview_file = self.writeLeaflet(iface, layer_list=layers,
+                                              popup=popup,
+                                              visible=visible,
+                                              json=json,
+                                              cluster=cluster,
+                                              params=params,
+                                              folder=dest_folder)
+        return self.preview_file
+
     @classmethod
     def writeLeaflet(
-            cls, iface, outputProjectFileName,
+            cls, iface, folder,
             layer_list, visible, cluster,
             json, params, popup):
+        outputProjectFileName = folder
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         legends = {}
         canvas = iface.mapCanvas()

--- a/maindialog.py
+++ b/maindialog.py
@@ -445,7 +445,7 @@ class MainDialog(QDialog, Ui_MainDialog):
             for param, item in settings.iteritems():
                 QgsProject.instance().writeEntry("qgis2web",
                                                  param.replace(" ", ""),
-                                                 item.setting())
+                                                 item.value())
         EXPORTER_REGISTRY.writeToProject(self.exporter)
         basemaps = self.basemaps.selectedItems()
         basemaplist = ",".join(basemap.text() for basemap in basemaps)
@@ -720,15 +720,5 @@ class TreeSettingItem(QTreeWidgetItem):
             return float(self.text(1))
         elif isinstance(self._value, tuple):
             return self.combo.currentText()
-        else:
-            return self.text(1)
-
-    def setting(self):
-        if isinstance(self._value, bool):
-            return self.checkState(1) == Qt.Checked
-        elif isinstance(self._value, (int, float)):
-            return float(self.text(1))
-        elif isinstance(self._value, tuple):
-            return self.combo.currentIndex()
         else:
             return self.text(1)

--- a/maindialog.py
+++ b/maindialog.py
@@ -408,22 +408,34 @@ class MainDialog(QDialog, Ui_MainDialog):
         (layers, groups, popup, visible,
          json, cluster) = self.getLayersAndGroups()
         params = self.getParameters()
-        previewFile = OpenLayersWriter.writeOL(self.iface, layers,
-                                               groups, popup,
-                                               visible, json,
-                                               cluster, params,
-                                               utils.tempFolder())
+
+        writer = OpenLayersWriter()
+        previewFile = writer.write(self.iface,
+                                   groups=groups,
+                                   layers=layers,
+                                   popup=popup,
+                                   visible=visible,
+                                   cluster=cluster,
+                                   json=json,
+                                   params=params,
+                                   dest_folder=utils.tempFolder())
         self.loadPreviewFile(previewFile)
 
     def previewLeaflet(self):
         (layers, groups, popup, visible,
          json, cluster) = self.getLayersAndGroups()
         params = self.getParameters()
-        previewFile = LeafletWriter.writeLeaflet(self.iface,
-                                                 utils.tempFolder(),
-                                                 layers, visible,
-                                                 cluster, json,
-                                                 params, popup)
+
+        writer = LeafletWriter()
+        previewFile = writer.write(self.iface,
+                                   groups=groups,
+                                   layers=layers,
+                                   popup=popup,
+                                   visible=visible,
+                                   cluster=cluster,
+                                   json=json,
+                                   params=params,
+                                   dest_folder=utils.tempFolder())
         self.loadPreviewFile(previewFile)
 
     def saveOL(self):
@@ -432,11 +444,16 @@ class MainDialog(QDialog, Ui_MainDialog):
         if write_folder:
             (layers, groups, popup, visible,
              json, cluster) = self.getLayersAndGroups()
-            outputFile = OpenLayersWriter.writeOL(self.iface, layers,
-                                                  groups, popup,
-                                                  visible, json,
-                                                  cluster, params,
-                                                  write_folder)
+            writer = OpenLayersWriter()
+            outputFile = writer.write(self.iface,
+                                       groups=groups,
+                                       layers=layers,
+                                       popup=popup,
+                                       visible=visible,
+                                       cluster=cluster,
+                                       json=json,
+                                       params=params,
+                                       dest_folder=write_folder)
             self.exporter.postProcess(outputFile)
             if (not os.environ.get('CI') and
                     not os.environ.get('TRAVIS')):
@@ -448,9 +465,16 @@ class MainDialog(QDialog, Ui_MainDialog):
         if write_folder:
             (layers, groups, popup, visible,
              json, cluster) = self.getLayersAndGroups()
-            outputFile = LeafletWriter.writeLeaflet(
-                self.iface, write_folder, layers, visible,
-                cluster, json, params, popup)
+            writer = LeafletWriter()
+            outputFile = writer.write(self.iface,
+                                       groups=groups,
+                                       layers=layers,
+                                       popup=popup,
+                                       visible=visible,
+                                       cluster=cluster,
+                                       json=json,
+                                       params=params,
+                                       dest_folder=write_folder)
             self.exporter.postProcess(outputFile)
             webbrowser.open_new_tab(self.exporter.destinationUrl())
 

--- a/maindialog.py
+++ b/maindialog.py
@@ -452,7 +452,7 @@ class MainDialog(QDialog, Ui_MainDialog):
                     parameters["Appearance"]["Search layer"] = (
                         self.layer_search_combo.itemData(
                             self.layer_search_combo.currentIndex()))
-        basemaps = self.basemaps.selectedItems()
+        basemaps = [i.text() for i in self.basemaps.selectedItems()]
         parameters["Appearance"]["Base layer"] = basemaps
         return parameters
 

--- a/maindialog.py
+++ b/maindialog.py
@@ -252,24 +252,6 @@ class MainDialog(QDialog, Ui_MainDialog):
                 not os.environ.get('TRAVIS')):
             webbrowser.open_new_tab(self.exporter.destinationUrl())
 
-    def saveSettings(self, paramItem, col):
-        QgsProject.instance().removeEntry("qgis2web",
-                                          paramItem.name.replace(" ", ""))
-        if isinstance(paramItem._value, bool):
-            QgsProject.instance().writeEntry("qgis2web",
-                                             paramItem.name.replace(" ", ""),
-                                             paramItem.checkState(col))
-        else:
-            QgsProject.instance().writeEntry("qgis2web",
-                                             paramItem.name.replace(" ", ""),
-                                             paramItem.text(col))
-        if paramItem.name == "Match project CRS":
-            baseLayer = self.basemaps
-            if paramItem.checkState(col):
-                baseLayer.setDisabled(True)
-            else:
-                baseLayer.setDisabled(False)
-
     def populate_layers_and_groups(self, dlg):
         """Populate layers on QGIS into our layers and group tree view."""
         root_node = QgsProject.instance().layerTreeRoot()

--- a/maindialog.py
+++ b/maindialog.py
@@ -17,6 +17,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import os
 import sys
 from collections import defaultdict, OrderedDict
 import webbrowser
@@ -24,6 +25,13 @@ import webbrowser
 # This import is to enable SIP API V2
 # noinspection PyUnresolvedReferences
 import qgis  # pylint: disable=unused-import
+from qgis.core import (QGis,
+                       QgsProject,
+                       QgsMapLayer,
+                       QgsVectorLayer,
+                       QgsNetworkAccessManager,
+                       QgsMessageLog)
+
 # noinspection PyUnresolvedReferences
 from PyQt4.QtCore import *
 from PyQt4.QtCore import (QSettings,
@@ -45,8 +53,9 @@ from configparams import (getParams,
                           baselayers,
                           specificParams,
                           specificOptions)
-from olwriter import writeOL
-from leafletWriter import *
+from olwriter import OpenLayersWriter
+from leafletWriter import LeafletWriter
+
 from exporter import (EXPORTER_REGISTRY)
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -399,16 +408,22 @@ class MainDialog(QDialog, Ui_MainDialog):
         (layers, groups, popup, visible,
          json, cluster) = self.getLayersAndGroups()
         params = self.getParameters()
-        previewFile = writeOL(self.iface, layers, groups, popup, visible, json,
-                              cluster, params, utils.tempFolder())
+        previewFile = OpenLayersWriter.writeOL(self.iface, layers,
+                                               groups, popup,
+                                               visible, json,
+                                               cluster, params,
+                                               utils.tempFolder())
         self.loadPreviewFile(previewFile)
 
     def previewLeaflet(self):
         (layers, groups, popup, visible,
          json, cluster) = self.getLayersAndGroups()
         params = self.getParameters()
-        previewFile = writeLeaflet(self.iface, utils.tempFolder(), layers,
-                                   visible, cluster, json, params, popup)
+        previewFile = LeafletWriter.writeLeaflet(self.iface,
+                                                 utils.tempFolder(),
+                                                 layers, visible,
+                                                 cluster, json,
+                                                 params, popup)
         self.loadPreviewFile(previewFile)
 
     def saveOL(self):
@@ -417,8 +432,11 @@ class MainDialog(QDialog, Ui_MainDialog):
         if write_folder:
             (layers, groups, popup, visible,
              json, cluster) = self.getLayersAndGroups()
-            outputFile = writeOL(self.iface, layers, groups, popup, visible,
-                                 json, cluster, params, write_folder)
+            outputFile = OpenLayersWriter.writeOL(self.iface, layers,
+                                                  groups, popup,
+                                                  visible, json,
+                                                  cluster, params,
+                                                  write_folder)
             self.exporter.postProcess(outputFile)
             if (not os.environ.get('CI') and
                     not os.environ.get('TRAVIS')):
@@ -430,7 +448,7 @@ class MainDialog(QDialog, Ui_MainDialog):
         if write_folder:
             (layers, groups, popup, visible,
              json, cluster) = self.getLayersAndGroups()
-            outputFile = writeLeaflet(
+            outputFile = LeafletWriter.writeLeaflet(
                 self.iface, write_folder, layers, visible,
                 cluster, json, params, popup)
             self.exporter.postProcess(outputFile)

--- a/maindialog.py
+++ b/maindialog.py
@@ -173,6 +173,18 @@ class MainDialog(QDialog, Ui_MainDialog):
         elif self.mapFormat.checkedButton() == self.leaflet:
             return LeafletWriter
 
+    def createWriter(self):
+        """
+        Creates a writer object reflecting the current settings
+        in the dialog
+        """
+        writer = self.getWriterFactory()()
+        (writer.layers, writer.groups, writer.popup,
+         writer.visible, writer.json,
+         writer.cluster) = self.getLayersAndGroups()
+        writer.params = self.getParameters()
+        return writer
+
     def toggleOptions(self):
         currentWriter = self.getWriterFactory()
         for param, value in specificParams.iteritems():
@@ -206,18 +218,8 @@ class MainDialog(QDialog, Ui_MainDialog):
                         treeOption.setDisabled(False)
 
     def createPreview(self):
-        writer = self.getWriterFactory()()
-        (layers, groups, popup, visible,
-         json, cluster) = self.getLayersAndGroups()
-        params = self.getParameters()
+        writer = self.createWriter()
         return writer.write(self.iface,
-                            groups=groups,
-                            layers=layers,
-                            popup=popup,
-                            visible=visible,
-                            cluster=cluster,
-                            json=json,
-                            params=params,
                             dest_folder=utils.tempFolder())
 
     def previewMap(self):
@@ -238,22 +240,12 @@ class MainDialog(QDialog, Ui_MainDialog):
                                      level=QgsMessageLog.CRITICAL)
 
     def saveMap(self):
-        writer = self.getWriterFactory()()
-        params = self.getParameters()
+        writer = self.createWriter()
         write_folder = self.exporter.exportDirectory()
         if not write_folder:
             return
 
-        (layers, groups, popup, visible,
-         json, cluster) = self.getLayersAndGroups()
         outputFile = writer.write(self.iface,
-                                  groups=groups,
-                                  layers=layers,
-                                  popup=popup,
-                                  visible=visible,
-                                  cluster=cluster,
-                                  json=json,
-                                  params=params,
                                   dest_folder=write_folder)
         self.exporter.postProcess(outputFile)
         if (not os.environ.get('CI') and

--- a/olwriter.py
+++ b/olwriter.py
@@ -56,15 +56,14 @@ class OpenLayersWriter(Writer):
     def name(cls):
         return QObject.tr(translator, 'OpenLayers')
 
-    def write(self, iface, groups, layers, visible,
-              cluster, popup, json, params, dest_folder):
-        self.preview_file = self.writeOL(iface, layers=layers,
-                                         groups=groups,
-                                         popup=popup,
-                                         visible=visible,
-                                         json=json,
-                                         clustered=cluster,
-                                         settings=params,
+    def write(self, iface, dest_folder):
+        self.preview_file = self.writeOL(iface, layers=self.layers,
+                                         groups=self.groups,
+                                         popup=self.popup,
+                                         visible=self.visible,
+                                         json=self.json,
+                                         clustered=self.cluster,
+                                         settings=self.params,
                                          folder=dest_folder)
         return self.preview_file
 

--- a/olwriter.py
+++ b/olwriter.py
@@ -351,7 +351,7 @@ def writeLayersAndGroups(layers, groups, visible, folder, popup,
 
     canvas = iface.mapCanvas()
     basemapList = settings["Appearance"]["Base layer"]
-    basemaps = [basemapOL()[item.text()] for _, item in enumerate(basemapList)]
+    basemaps = [basemapOL()[item] for _, item in enumerate(basemapList)]
     if len(basemapList) > 1:
         baseGroup = "Base maps"
     else:

--- a/olwriter.py
+++ b/olwriter.py
@@ -56,6 +56,18 @@ class OpenLayersWriter(Writer):
     def name(cls):
         return QObject.tr(translator, 'OpenLayers')
 
+    def write(self, iface, groups, layers, visible,
+              cluster, popup, json, params, dest_folder):
+        self.preview_file = self.writeOL(iface, layers=layers,
+                                         groups=groups,
+                                         popup=popup,
+                                         visible=visible,
+                                         json=json,
+                                         clustered=cluster,
+                                         settings=params,
+                                         folder=dest_folder)
+        return self.preview_file
+
     @classmethod
     def writeOL(cls, iface, layers, groups, popup, visible,
                 json, clustered, settings, folder):

--- a/olwriter.py
+++ b/olwriter.py
@@ -35,9 +35,11 @@ from PyQt4.QtGui import *
 from olScriptStrings import *
 from basemaps import basemapOL
 from writer import (Writer,
-    translator)
+                    translator)
+
 
 class OpenLayersWriter(Writer):
+
     """
     Writer for creation of web maps based on the OpenLayers
     JavaScript library.
@@ -78,8 +80,8 @@ class OpenLayersWriter(Writer):
                          optimize, popup, json, restrictToExtent, extent)
             exportStyles(layers, folder, clustered)
             osmb = writeLayersAndGroups(layers, groups, visible, folder, popup,
-                                        settings, json, matchCRS, clustered, iface,
-                                        restrictToExtent, extent)
+                                        settings, json, matchCRS, clustered,
+                                        iface, restrictToExtent, extent)
             jsAddress = '<script src="resources/polyfills.js"></script>'
             if settings["Data export"]["Mapping library location"] == "Local":
                 cssAddress = """<link rel="stylesheet" """
@@ -147,15 +149,17 @@ class OpenLayersWriter(Writer):
                             layerSource += wfsSRS
                         if not matchCRS:
                             layerSource = re.sub('SRSNAME\=EPSG\:\d+',
-                                                 'SRSNAME=EPSG:3857', layerSource)
+                                                 'SRSNAME=EPSG:3857',
+                                                 layerSource)
                         layerSource += "&outputFormat=text%2Fjavascript&"
                         layerSource += "format_options=callback%3A"
                         layerSource += "get" + sln + "Json"
                         wfsVars += ('<script src="%s"></script>' % layerSource)
-                    styleVars += ('<script src="styles/%s_style.js"></script>' %
+                    styleVars += ('<script src="styles/%s_style.js">'
+                                  '</script>' %
                                   (sln))
             popupLayers = "popupLayers = [%s];" % ",".join(
-                    ['1' for field in popup])
+                ['1' for field in popup])
             controls = ['expandedAttribution']
             project = QgsProject.instance()
             if project.readBoolEntry("ScaleBar", "/Enabled", False)[0]:
@@ -196,14 +200,16 @@ class OpenLayersWriter(Writer):
             highlightFill = mapSettings.selectionColor().name()
             proj4 = ""
             proj = ""
-            view = "%s maxZoom: %d, minZoom: %d" % (mapextent, maxZoom, minZoom)
+            view = "%s maxZoom: %d, minZoom: %d" % (
+                mapextent, maxZoom, minZoom)
             if settings["Appearance"]["Match project CRS"]:
                 proj4 = """
 <script src="http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.6/proj4.js">"""
                 proj4 += "</script>"
-                proj = "<script>proj4.defs('{epsg}','{defn}');</script>".format(
-                    epsg=mapSettings.destinationCrs().authid(),
-                    defn=mapSettings.destinationCrs().toProj4())
+                proj = "<script>proj4.defs('{epsg}','{defn}');</script>"\
+                    .format(
+                        epsg=mapSettings.destinationCrs().authid(),
+                        defn=mapSettings.destinationCrs().toProj4())
                 view += ", projection: '%s'" % (
                     mapSettings.destinationCrs().authid())
             if settings["Appearance"]["Measure tool"] != "None":
@@ -297,7 +303,8 @@ class OpenLayersWriter(Writer):
                 htmlTemplate = settings["Appearance"]["Template"]
                 if htmlTemplate == "":
                     htmlTemplate = "basic"
-                templateOutput = replaceInTemplate(htmlTemplate + ".html", values)
+                templateOutput = replaceInTemplate(
+                    htmlTemplate + ".html", values)
                 templateOutput = re.sub('\n[\s_]+\n', '\n', templateOutput)
                 f.write(templateOutput)
             values = {"@GEOLOCATEHEAD@": geolocateHead,
@@ -315,7 +322,8 @@ class OpenLayersWriter(Writer):
                       "@MEASURING@": measuring,
                       "@MEASURE@": measure,
                       "@MEASUREUNIT@": measureUnit}
-            with open(os.path.join(folder, "resources", "qgis2web.js"), "w") as f:
+            with open(os.path.join(folder, "resources", "qgis2web.js"),
+                      "w") as f:
                 out = replaceInScript("qgis2web.js", values)
                 f.write(out.encode("utf-8"))
         except Exception as e:
@@ -382,7 +390,7 @@ def writeLayersAndGroups(layers, groups, visible, folder, popup,
                 shadows = ""
                 renderer = layer.rendererV2()
                 renderContext = QgsRenderContext.fromMapSettings(
-                        canvas.mapSettings())
+                    canvas.mapSettings())
                 fields = layer.pendingFields()
                 renderer.startRender(renderContext, fields)
                 for feat in layer.getFeatures():
@@ -465,38 +473,38 @@ osmb.set(geojson_{sln});""".format(shadows=shadows, sln=safeName(layer.name()))
             labelFields = ""
             for field, label in zip(labels.keys(), labels.values()):
                 labelFields += "'%(field)s': '%(label)s', " % (
-                        {"field": field, "label": label})
+                    {"field": field, "label": label})
             labelFields = "{%(labelFields)s});\n" % (
-                    {"labelFields": labelFields})
+                {"labelFields": labelFields})
             labelFields = "lyr_%(name)s.set('fieldLabels', " % (
-                        {"name": sln}) + labelFields
+                {"name": sln}) + labelFields
             fieldLabels += labelFields
             for f in fieldList:
                 fieldIndex = fieldList.indexFromName(unicode(f.name()))
                 aliasFields += "'%(field)s': '%(alias)s', " % (
-                        {"field": f.name(),
-                         "alias": layer.attributeDisplayName(fieldIndex)})
+                    {"field": f.name(),
+                     "alias": layer.attributeDisplayName(fieldIndex)})
                 try:
                     widget = layer.editFormConfig().widgetType(fieldIndex)
                 except:
                     widget = layer.editorWidgetV2(fieldIndex)
                 imageFields += "'%(field)s': '%(image)s', " % (
-                        {"field": f.name(),
-                         "image": widget})
+                    {"field": f.name(),
+                     "image": widget})
             aliasFields = "{%(aliasFields)s});\n" % (
-                        {"aliasFields": aliasFields})
+                {"aliasFields": aliasFields})
             aliasFields = "lyr_%(name)s.set('fieldAliases', " % (
-                        {"name": sln}) + aliasFields
+                {"name": sln}) + aliasFields
             fieldAliases += aliasFields
             imageFields = "{%(imageFields)s});\n" % (
-                        {"imageFields": imageFields})
+                {"imageFields": imageFields})
             imageFields = "lyr_%(name)s.set('fieldImages', " % (
-                        {"name": sln}) + imageFields
+                {"name": sln}) + imageFields
             fieldImages += imageFields
             blend_mode = """lyr_%(name)s.on('precompose', function(evt) {
     evt.context.globalCompositeOperation = '%(blend)s';
 });""" % (
-                        {"name": sln,
+                {"name": sln,
                          "blend": BLEND_MODES[layer.blendMode()]})
 
     path = os.path.join(folder, "layers", "layers.js")
@@ -643,8 +651,8 @@ function get%(n)sJson(geojson) {
     var features_%(n)s = format_%(n)s.readFeatures(geojson);
     jsonSource_%(n)s.addFeatures(features_%(n)s);
 }''' % {
-                        "name": layer.name(), "n": layerName,
-                        "min": minResolution, "max": maxResolution}
+                "name": layer.name(), "n": layerName,
+                "min": minResolution, "max": maxResolution}
             return layerCode
         else:
             layerCode = '''var format_%(n)s = new ol.format.GeoJSON();
@@ -1024,7 +1032,7 @@ def getSymbolAsStyle(symbol, stylesFolder, layer_transparency):
     if layer_transparency == 0:
         alpha = symbol.alpha()
     else:
-        alpha = 1-(layer_transparency / float(100))
+        alpha = 1 - (layer_transparency / float(100))
     for i in xrange(symbol.symbolLayerCount()):
         sl = symbol.symbolLayer(i)
         props = sl.properties()
@@ -1127,7 +1135,7 @@ def getCircle(color, borderColor, borderWidth, size, props):
 def getIcon(path, size, svgWidth, svgHeight, rot):
     size = math.floor(float(size) * 3.8)
     anchor = size / 2
-    scale = unicode(float(size)/float(svgWidth))
+    scale = unicode(float(size) / float(svgWidth))
     return '''new ol.style.Icon({
                   imgSize: [%(w)s, %(h)s],
                   scale: %(scale)s,

--- a/test/test_qgis2web_dialog.py
+++ b/test/test_qgis2web_dialog.py
@@ -36,7 +36,9 @@ QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 
 from maindialog import MainDialog
 
+
 class qgis2web_classDialogTest(unittest.TestCase):
+
     """Test most common plugin actions"""
 
     def setUp(self):
@@ -57,8 +59,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         Set template to match desired control output
         """
         combo = self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Template',
+            self.dialog.paramsTreeOL.findItems(
+                'Template',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1)
 
@@ -67,15 +69,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
     def defaultParams(self):
         return {'Data export': {
-                             'Mapping library location' : 'Local',
+            'Mapping library location': 'Local',
                              'Minify GeoJSON files': False,
                              'Exporter': 'Export to folder',
                              'Precision': 'maintain'},
-            'Scale/Zoom': {'Min zoom level': '1',
-                           'Restrict to extent': False,
-                           'Extent': 'Fit to layers extent',
-                           'Max zoom level': '28'},
-            'Appearance': {
+                'Scale/Zoom': {'Min zoom level': '1',
+                               'Restrict to extent': False,
+                               'Extent': 'Fit to layers extent',
+                               'Max zoom level': '28'},
+                'Appearance': {
                 'Add address search': False,
                 'Geolocate user': False,
                 'Base layer': [],
@@ -87,7 +89,7 @@ class qgis2web_classDialogTest(unittest.TestCase):
                 'Layer search': 'None',
                 'Highlight on hover': False,
                 'Show popups on hover': False
-            }}
+        }}
 
     def test01_preview_default(self):
         """Preview default - no data (OL3)"""
@@ -105,7 +107,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.leaflet.click()
         self.assertEqual(self.dialog.currentMapFormat(), LeafletWriter.type())
         self.dialog.ol3.click()
-        self.assertEqual(self.dialog.currentMapFormat(), OpenLayersWriter.type())
+        self.assertEqual(
+            self.dialog.currentMapFormat(), OpenLayersWriter.type())
 
     def test02b_toggle_format_factory(self):
         """ test fetching factory for current writer type"""
@@ -164,30 +167,30 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
-        self.assertEqual(writer.popup,[OrderedDict(
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup, [OrderedDict(
             [('ID', 'no label'), ('fk_region', 'no label'), ('ELEV', 'no label'), ('NAME', 'no label'),
              ('USE', 'no label')])])
-        self.assertEqual(writer.json,[False])
-
+        self.assertEqual(writer.json, [False])
 
     def test10_Leaflet_wfs_pnt_single(self):
         """Dialog test: Leaflet  WFS point single"""
-        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
+        layer_url = (
+            'http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
         layer_style = test_data_path('style', 'point_single.qml')
         layer = load_wfs_layer(layer_url, 'point')
         layer.loadNamedStyle(layer_style)
@@ -197,24 +200,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
-        self.assertEqual(writer.popup,[OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
-])
-        self.assertEqual(writer.json,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup, [OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
+                                        ])
+        self.assertEqual(writer.json, [False])
 
     def test11_Leaflet_json_line_single(self):
         """Dialog test: Leaflet  JSON line single"""
@@ -228,23 +231,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
-        self.assertEqual(writer.popup,[OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'), (u'F_CODEDESC', u'no label')])
-])
-        self.assertEqual(writer.json,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup, [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'), (u'F_CODEDESC', u'no label')])
+                                        ])
+        self.assertEqual(writer.json, [False])
 
     def test12_Leaflet_wfs_line_single(self):
         """Dialog test: Leaflet  WFS line single"""
@@ -260,23 +263,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
-        self.assertEqual(writer.popup,[OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
-])
-        self.assertEqual(writer.json,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup, [OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
+                                        ])
+        self.assertEqual(writer.json, [False])
 
     def test13_Leaflet_json_poly_single(self):
         """Dialog test: Leaflet  JSON polygon single"""
@@ -290,23 +293,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
-        self.assertEqual(writer.popup,[OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'), (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])
-])
-        self.assertEqual(writer.json,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup, [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'), (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])
+                                        ])
+        self.assertEqual(writer.json, [False])
 
     def test14_Leaflet_wfs_poly_single(self):
         """Dialog test: Leaflet  WFS polygon single"""
@@ -315,7 +318,7 @@ class qgis2web_classDialogTest(unittest.TestCase):
                      '=dnpa_inspire:con_areas&SRSNAME=EPSG:27700')
         layer_style = test_data_path('style', 'polygon_single.qml')
         control_path = test_data_path(
-                'control', 'leaflet_wfs_polygon_single.html')
+            'control', 'leaflet_wfs_polygon_single.html')
         layer = load_wfs_layer(layer_url, 'polygon')
         layer.loadNamedStyle(layer_style)
 
@@ -324,30 +327,30 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
-        self.assertEqual(writer.popup,[OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'), (u'area_ha', u'no label'), (u'web_page', u'no label')])
-])
-        self.assertEqual(writer.json,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup, [OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'), (u'area_ha', u'no label'), (u'web_page', u'no label')])
+                                        ])
+        self.assertEqual(writer.json, [False])
 
     def test15_Leaflet_json_pnt_categorized(self):
         """Dialog test: Leaflet  JSON point categorized"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_categorized.qml')
         control_path = test_data_path(
-                'control', 'leaflet_json_point_categorized.html')
+            'control', 'leaflet_json_point_categorized.html')
 
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
@@ -357,31 +360,32 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
-        self.assertEqual(writer.popup,[OrderedDict(
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup, [OrderedDict(
             [('ID', 'no label'), ('fk_region', 'no label'), ('ELEV', 'no label'), ('NAME', 'no label'),
              ('USE', 'no label')])])
-        self.assertEqual(writer.json,[False])
+        self.assertEqual(writer.json, [False])
 
     def test16_Leaflet_wfs_pnt_categorized(self):
         """Dialog test: Leaflet  WFS point categorized"""
-        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
+        layer_url = (
+            'http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
         layer_style = test_data_path('style', 'wfs_point_categorized.qml')
         control_path = test_data_path(
-                'control', 'leaflet_wfs_point_categorized.html')
+            'control', 'leaflet_wfs_point_categorized.html')
         layer = load_wfs_layer(layer_url, 'point')
         layer.loadNamedStyle(layer_style)
 
@@ -390,30 +394,30 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
-        self.assertEqual(writer.popup,[OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
-])
-        self.assertEqual(writer.json,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup, [OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
+                                        ])
+        self.assertEqual(writer.json, [False])
 
     def test17_Leaflet_json_line_categorized(self):
         """Dialog test: Leaflet  JSON line categorized"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         style_path = test_data_path('style', 'pipelines_categorized.qml')
         control_path = test_data_path(
-                'control', 'leaflet_json_line_categorized.html')
+            'control', 'leaflet_json_line_categorized.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -422,24 +426,25 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
-                          (u'F_CODEDESC', u'no label')])])
-        self.assertEqual(writer.json,[False])
+                         [OrderedDict(
+                             [(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                              (u'F_CODEDESC', u'no label')])])
+        self.assertEqual(writer.json, [False])
 
     def test18_Leaflet_wfs_line_categorized(self):
         """Dialog test: Leaflet  WFS line categorized"""
@@ -448,7 +453,7 @@ class qgis2web_classDialogTest(unittest.TestCase):
                      '=broads_inspire:centreline&SRSNAME=EPSG:27700')
         layer_style = test_data_path('style', 'wfs_line_categorized.qml')
         control_path = test_data_path(
-                'control', 'leaflet_wfs_line_categorized.html')
+            'control', 'leaflet_wfs_line_categorized.html')
         layer = load_wfs_layer(layer_url, 'centreline')
         layer.loadNamedStyle(layer_style)
 
@@ -457,31 +462,31 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
                          [OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
-])
-        self.assertEqual(writer.json,[False])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test19_Leaflet_json_poly_categorized(self):
         """Dialog test: Leaflet  JSON polygon categorized"""
         layer_path = test_data_path('layer', 'lakes.shp')
         style_path = test_data_path('style', 'lakes_categorized.qml')
         control_path = test_data_path(
-                'control', 'leaflet_json_polygon_categorized.html')
+            'control', 'leaflet_json_polygon_categorized.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -490,24 +495,25 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
-                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])])
-        self.assertEqual(writer.json,[False])
+                         [OrderedDict(
+                             [(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                              (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])])
+        self.assertEqual(writer.json, [False])
 
     def test20_Leaflet_wfs_poly_categorized(self):
         """Dialog test: Leaflet  WFS polygon categorized"""
@@ -523,23 +529,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
                          [OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'), (u'area_ha', u'no label'), (u'web_page', u'no label')])
-])
-        self.assertEqual(writer.json,[False])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test21_Leaflet_json_pnt_graduated(self):
         """Dialog test: Leaflet  JSON point graduated"""
@@ -553,29 +559,31 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])]
                          )
-        self.assertEqual(writer.json,[False])
+        self.assertEqual(writer.json, [False])
 
     def test22_Leaflet_wfs_pnt_graduated(self):
         """Dialog test: Leaflet  WFS point graduated"""
-        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
+        layer_url = (
+            'http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
         layer_style = test_data_path('style', 'wfs_point_graduated.qml')
         layer = load_wfs_layer(layer_url, 'point')
         layer.loadNamedStyle(layer_style)
@@ -585,24 +593,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
                          [OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
-])
-        self.assertEqual(writer.json,[False])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test23_Leaflet_json_line_graduated(self):
         """Dialog test: Leaflet  JSON line graduated"""
@@ -616,25 +624,26 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'), (u'F_CODEDESC', u'no label')])]
+                         [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (
+                             u'F_CODE', u'no label'), (u'F_CODEDESC', u'no label')])]
 
                          )
-        self.assertEqual(writer.json,[False])
+        self.assertEqual(writer.json, [False])
 
     def test24_Leaflet_wfs_line_graduated(self):
         """Dialog test: Leaflet  WFS line graduated"""
@@ -650,25 +659,25 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
                          [OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
-]
+                          ]
                          )
-        self.assertEqual(writer.json,[False])
+        self.assertEqual(writer.json, [False])
 
     def test25_Leaflet_json_poly_graduated(self):
         """Dialog test: Leaflet  JSON polygon graduated"""
@@ -682,25 +691,26 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
-                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+                         [OrderedDict(
+                             [(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                              (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
                          )
-        self.assertEqual(writer.json,[False])
+        self.assertEqual(writer.json, [False])
 
     def test26_Leaflet_wfs_poly_graduated(self):
         """Dialog test: Leaflet  WFS polygon graduated"""
@@ -716,25 +726,26 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, LeafletWriter ))
+        self.assertTrue(isinstance(writer, LeafletWriter))
         expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
- [                        OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'),
-                                      (u'area_ha', u'no label'), (u'web_page', u'no label')])
-]                         )
-        self.assertEqual(writer.json,[False])
+                         [OrderedDict(
+                          [(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'),
+                           (u'area_ha', u'no label'), (u'web_page', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test27_OL3_pnt_single(self):
         """Dialog test: OL3   point single"""
@@ -748,40 +759,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
-                1).setCurrentIndex(1)
-        self.setTemplate('full-screen')
-        self.dialog.ol3.click()
-
-        writer = self.dialog.createWriter()
-        self.assertTrue(isinstance(writer, OpenLayersWriter ))
-        expected_params = self.defaultParams()
-        self.assertEqual(writer.params,expected_params)
-        self.assertEqual(writer.groups,{})
-        self.assertEqual(writer.layers,[layer])
-        self.assertEqual(writer.visible,[True])
-        self.assertEqual(writer.cluster,[False])
-        self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'), (u'NAME', u'no label'), (u'USE', u'no label')])
-]
-                         )
-        self.assertEqual(writer.json,[False])
-
-    def test28_OL3_line_single(self):
-        """Dialog test: OL3   line single"""
-        layer_path = test_data_path('layer', 'pipelines.shp')
-        style_path = test_data_path('style', 'pipelines_single.qml')
-        layer = load_layer(layer_path)
-        layer.loadNamedStyle(style_path)
-
-        registry = QgsMapLayerRegistry.instance()
-        registry.addMapLayer(layer)
-
-        self.dialog = MainDialog(IFACE)
-        self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
@@ -795,8 +774,41 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
-                                       (u'F_CODEDESC', u'no label')])]
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'), (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+                         )
+        self.assertEqual(writer.json, [False])
+
+    def test28_OL3_line_single(self):
+        """Dialog test: OL3   line single"""
+        layer_path = test_data_path('layer', 'pipelines.shp')
+        style_path = test_data_path('style', 'pipelines_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        self.dialog = MainDialog(IFACE)
+        self.dialog.paramsTreeOL.itemWidget(
+            self.dialog.paramsTreeOL.findItems(
+                'Extent', (Qt.MatchExactly | Qt.MatchRecursive))[0],
+                1).setCurrentIndex(1)
+        self.setTemplate('full-screen')
+        self.dialog.ol3.click()
+
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict(
+                             [(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                              (u'F_CODEDESC', u'no label')])]
                          )
         self.assertEqual(writer.json, [False])
 
@@ -811,9 +823,10 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         self.dialog = MainDialog(IFACE)
-        self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
-                                                (Qt.MatchExactly |
-                                                 Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
+        self.dialog.paramsTreeOL.itemWidget(
+            self.dialog.paramsTreeOL.findItems("Extent",
+                                               (Qt.MatchExactly |
+                                                Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
         writer = self.dialog.createWriter()
@@ -825,8 +838,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
-                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+                         [OrderedDict(
+                             [(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                              (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
                          )
         self.assertEqual(writer.json, [False])
 
@@ -842,8 +856,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        "Extent", (Qt.MatchExactly | Qt.MatchRecursive))[0],
+            self.dialog.paramsTreeOL.findItems(
+                "Extent", (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
@@ -857,8 +871,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])]
                          )
         self.assertEqual(writer.json, [False])
 
@@ -873,9 +888,10 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         self.dialog = MainDialog(IFACE)
-        self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
-                                                (Qt.MatchExactly |
-                                                 Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
+        self.dialog.paramsTreeOL.itemWidget(
+            self.dialog.paramsTreeOL.findItems("Extent",
+                                               (Qt.MatchExactly |
+                                                Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
         writer = self.dialog.createWriter()
@@ -887,8 +903,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
-                                       (u'F_CODEDESC', u'no label')])]
+                         [OrderedDict(
+                             [(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                              (u'F_CODEDESC', u'no label')])]
                          )
         self.assertEqual(writer.json, [False])
 
@@ -903,9 +920,10 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         self.dialog = MainDialog(IFACE)
-        self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
-                                                (Qt.MatchExactly |
-                                                 Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
+        self.dialog.paramsTreeOL.itemWidget(
+            self.dialog.paramsTreeOL.findItems("Extent",
+                                               (Qt.MatchExactly |
+                                                Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
 
@@ -918,8 +936,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
-                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+                         [OrderedDict(
+                             [(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                              (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
                          )
         self.assertEqual(writer.json, [False])
 
@@ -934,9 +953,10 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         self.dialog = MainDialog(IFACE)
-        self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
-                                                (Qt.MatchExactly |
-                                                 Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
+        self.dialog.paramsTreeOL.itemWidget(
+            self.dialog.paramsTreeOL.findItems("Extent",
+                                               (Qt.MatchExactly |
+                                                Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
 
@@ -949,8 +969,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])]
                          )
         self.assertEqual(writer.json, [False])
 
@@ -965,9 +986,10 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         self.dialog = MainDialog(IFACE)
-        self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
-                                                (Qt.MatchExactly |
-                                                 Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
+        self.dialog.paramsTreeOL.itemWidget(
+            self.dialog.paramsTreeOL.findItems("Extent",
+                                               (Qt.MatchExactly |
+                                                Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
 
@@ -980,8 +1002,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
-                                       (u'F_CODEDESC', u'no label')])]
+                         [OrderedDict(
+                             [(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                              (u'F_CODEDESC', u'no label')])]
                          )
         self.assertEqual(writer.json, [False])
 
@@ -996,9 +1019,10 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         self.dialog = MainDialog(IFACE)
-        self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
-                                                (Qt.MatchExactly |
-                                                 Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
+        self.dialog.paramsTreeOL.itemWidget(
+            self.dialog.paramsTreeOL.findItems("Extent",
+                                               (Qt.MatchExactly |
+                                                Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
 
@@ -1011,8 +1035,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
-                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+                         [OrderedDict(
+                             [(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                              (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
                          )
         self.assertEqual(writer.json, [False])
 
@@ -1031,7 +1056,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         dialog.ol3.click()
 
         # Check the 'Add layers list' checkbox
-        dialog.items['Appearance'].get('Add layers list').setCheckState(1, QtCore.Qt.Checked)
+        dialog.items['Appearance'].get(
+            'Add layers list').setCheckState(1, QtCore.Qt.Checked)
 
         writer = dialog.createWriter()
         self.assertTrue(isinstance(writer, OpenLayersWriter))
@@ -1046,9 +1072,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
                          [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'), (u'NAME', u'no label'), (u'USE', u'no label')])
-])
+                          ])
         self.assertEqual(writer.json, [False])
-
 
     def test37_OL3_base_layers_have_type_base(self):
         """Dialog test: OL3   Ensure base layers have a type property with a value of 'base'"""
@@ -1069,7 +1094,7 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         writer = dialog.createWriter()
         self.assertTrue(isinstance(writer, OpenLayersWriter))
-        self.assertEqual(writer.params['Appearance']['Base layer'],['OSM'])
+        self.assertEqual(writer.params['Appearance']['Base layer'], ['OSM'])
 
     def test39_OL3_base_group_only_included_when_base_map_selected(self):
         """Dialog test: OL3   Only include the 'Base maps' group when +1 base maps are selected"""
@@ -1091,14 +1116,14 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         writer = dialog.createWriter()
         self.assertTrue(isinstance(writer, OpenLayersWriter))
-        self.assertEqual(len(writer.params['Appearance']['Base layer']),0)
+        self.assertEqual(len(writer.params['Appearance']['Base layer']), 0)
 
         # Select a base map
         dialog.basemaps.item(0).setSelected(True)
 
         writer = dialog.createWriter()
         self.assertTrue(isinstance(writer, OpenLayersWriter))
-        self.assertEqual(writer.params['Appearance']['Base layer'],['OSM'])
+        self.assertEqual(writer.params['Appearance']['Base layer'], ['OSM'])
 
     def test40_Leaflet_scalebar(self):
         """Dialog test: Leaflet  scale bar"""
@@ -1113,8 +1138,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
@@ -1133,8 +1158,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1149,16 +1175,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_scalebar.js'), 'r')
+            test_data_path(
+                'control', 'ol3_scalebar.js'), 'r')
         control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
@@ -1177,8 +1202,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1195,15 +1221,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
         # Set the 'Measure tool' combo
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Measure tool',
+            self.dialog.paramsTreeOL.findItems(
+                'Measure tool',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
@@ -1219,11 +1245,11 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
-
 
     def test43_OL3_measure(self):
         """Dialog test: OL3   measure control"""
@@ -1238,16 +1264,16 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
 
         # Set the 'Measure tool' combo
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Measure tool',
+            self.dialog.paramsTreeOL.findItems(
+                'Measure tool',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.dialog.ol3.click()
@@ -1262,8 +1288,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1280,13 +1307,14 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
         # Check the 'Add address search' checkbox
-        self.dialog.items['Appearance'].get('Add address search').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Appearance'].get(
+            'Add address search').setCheckState(1, QtCore.Qt.Checked)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
@@ -1300,8 +1328,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1318,14 +1347,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
 
         # Check the 'Add address search' checkbox
-        self.dialog.items['Appearance'].get('Add address search').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Appearance'].get(
+            'Add address search').setCheckState(1, QtCore.Qt.Checked)
         self.dialog.ol3.click()
 
         writer = self.dialog.createWriter()
@@ -1338,8 +1368,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1356,13 +1387,14 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
         # Check the 'Geolocate user' checkbox
-        self.dialog.items['Appearance'].get('Geolocate user').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Appearance'].get(
+            'Geolocate user').setCheckState(1, QtCore.Qt.Checked)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
@@ -1376,8 +1408,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1394,14 +1427,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
 
         # Check the 'Geolocate user' checkbox
-        self.dialog.items['Appearance'].get('Geolocate user').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Appearance'].get(
+            'Geolocate user').setCheckState(1, QtCore.Qt.Checked)
         self.dialog.ol3.click()
 
         writer = self.dialog.createWriter()
@@ -1415,8 +1449,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1433,13 +1468,14 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
         # Check the 'Highlight on hover' checkbox
-        self.dialog.items['Appearance'].get('Highlight on hover').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Appearance'].get(
+            'Highlight on hover').setCheckState(1, QtCore.Qt.Checked)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
@@ -1453,8 +1489,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1471,14 +1508,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
 
         # Check the 'Highlight on hover' checkbox
-        self.dialog.items['Appearance'].get('Highlight on hover').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Appearance'].get(
+            'Highlight on hover').setCheckState(1, QtCore.Qt.Checked)
         self.dialog.ol3.click()
 
         writer = self.dialog.createWriter()
@@ -1492,8 +1530,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1512,13 +1551,14 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
         # Check the 'Match project CRS' checkbox
-        self.dialog.items['Appearance'].get('Match project CRS').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Appearance'].get(
+            'Match project CRS').setCheckState(1, QtCore.Qt.Checked)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
@@ -1532,8 +1572,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1548,19 +1589,19 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry.addMapLayer(layer)
         crs = QgsCoordinateReferenceSystem("EPSG:2964")
         IFACE.mapCanvas().mapRenderer().setDestinationCrs(crs)
-        
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
 
                 # Check the 'Match project CRS' checkbox
-        self.dialog.items['Appearance'].get('Match project CRS').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Appearance'].get(
+            'Match project CRS').setCheckState(1, QtCore.Qt.Checked)
         self.dialog.ol3.click()
         writer = self.dialog.createWriter()
         self.assertTrue(isinstance(writer, OpenLayersWriter))
@@ -1572,8 +1613,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1590,13 +1632,14 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
         # Check the 'Add layers list' checkbox
-        self.dialog.items['Appearance'].get('Add layers list').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Appearance'].get(
+            'Add layers list').setCheckState(1, QtCore.Qt.Checked)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
@@ -1610,8 +1653,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1628,8 +1672,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
@@ -1647,8 +1691,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [False])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1665,8 +1710,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
@@ -1685,8 +1730,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [False])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1703,8 +1749,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
@@ -1722,8 +1768,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [True])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1740,8 +1787,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
@@ -1760,8 +1807,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [True])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1778,13 +1826,14 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
         # Set 'Precision' combo to '3'
-        self.dialog.items['Data export'].get('Precision').combo.setCurrentIndex(3)
+        self.dialog.items['Data export'].get(
+            'Precision').combo.setCurrentIndex(3)
         self.setTemplate('canvas-size')
         self.dialog.leaflet.click()
 
@@ -1799,8 +1848,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1817,14 +1867,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
 
         # Set 'Precision' combo to '2'
-        self.dialog.items['Data export'].get('Precision').combo.setCurrentIndex(2)
+        self.dialog.items['Data export'].get(
+            'Precision').combo.setCurrentIndex(2)
         self.dialog.ol3.click()
 
         writer = self.dialog.createWriter()
@@ -1838,8 +1889,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1856,14 +1908,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
 
         # Set 'Mapping library location' combo to 'CDN'
-        self.dialog.items['Data export'].get('Mapping library location').combo.setCurrentIndex(1)
+        self.dialog.items['Data export'].get(
+            'Mapping library location').combo.setCurrentIndex(1)
         self.dialog.leaflet.click()
 
         writer = self.dialog.createWriter()
@@ -1876,8 +1929,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1894,14 +1948,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
 
         # Set 'Mapping library location' combo to 'CDN'
-        self.dialog.items['Data export'].get('Mapping library location').combo.setCurrentIndex(1)
+        self.dialog.items['Data export'].get(
+            'Mapping library location').combo.setCurrentIndex(1)
         self.dialog.ol3.click()
 
         writer = self.dialog.createWriter()
@@ -1914,8 +1969,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1932,16 +1988,18 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
         # Check the 'Minify GeoJSON files' checkbox
-        self.dialog.items['Data export'].get('Minify GeoJSON files').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Data export'].get(
+            'Minify GeoJSON files').setCheckState(1, QtCore.Qt.Checked)
 
         # Set 'Precision' combo to '6'
-        self.dialog.items['Data export'].get('Precision').combo.setCurrentIndex(6)
+        self.dialog.items['Data export'].get(
+            'Precision').combo.setCurrentIndex(6)
         self.setTemplate('canvas-size')
         self.dialog.leaflet.click()
 
@@ -1957,8 +2015,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -1975,17 +2034,19 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
 
         # Check the 'Minify GeoJSON files' checkbox
-        self.dialog.items['Data export'].get('Minify GeoJSON files').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Data export'].get(
+            'Minify GeoJSON files').setCheckState(1, QtCore.Qt.Checked)
 
         # Set 'Precision' combo to '2'
-        self.dialog.items['Data export'].get('Precision').combo.setCurrentIndex(2)
+        self.dialog.items['Data export'].get(
+            'Precision').combo.setCurrentIndex(2)
         self.dialog.ol3.click()
 
         writer = self.dialog.createWriter()
@@ -2000,8 +2061,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -2018,8 +2080,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(0)
 
@@ -2037,8 +2099,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -2055,16 +2118,16 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
         # Set 'Max zoom' combo to '20'
-        self.dialog.items['Scale/Zoom'].get('Max zoom level').combo.setCurrentIndex(19)
+        self.dialog.items['Scale/Zoom'].get(
+            'Max zoom level').combo.setCurrentIndex(19)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
-
 
         writer = self.dialog.createWriter()
         self.assertTrue(isinstance(writer, LeafletWriter))
@@ -2076,8 +2139,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -2094,14 +2158,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
 
         # Set 'Max zoom level' combo to '20'
-        self.dialog.items['Scale/Zoom'].get('Max zoom level').combo.setCurrentIndex(19)
+        self.dialog.items['Scale/Zoom'].get(
+            'Max zoom level').combo.setCurrentIndex(19)
         self.dialog.ol3.click()
 
         writer = self.dialog.createWriter()
@@ -2115,8 +2180,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -2133,13 +2199,14 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
         # Set 'Min zoom' combo to '6'
-        self.dialog.items['Scale/Zoom'].get('Min zoom level').combo.setCurrentIndex(5)
+        self.dialog.items['Scale/Zoom'].get(
+            'Min zoom level').combo.setCurrentIndex(5)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
@@ -2153,8 +2220,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -2171,14 +2239,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
 
         # Set 'Min zoom level' combo to '6'
-        self.dialog.items['Scale/Zoom'].get('Min zoom level').combo.setCurrentIndex(5)
+        self.dialog.items['Scale/Zoom'].get(
+            'Min zoom level').combo.setCurrentIndex(5)
         self.dialog.ol3.click()
 
         writer = self.dialog.createWriter()
@@ -2192,8 +2261,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -2210,13 +2280,14 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
 
         # Check the 'Restrict to extent' checkbox
-        self.dialog.items['Scale/Zoom'].get('Restrict to extent').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Scale/Zoom'].get(
+            'Restrict to extent').setCheckState(1, QtCore.Qt.Checked)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
@@ -2230,8 +2301,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -2248,14 +2320,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
 
         # Check the 'Restrict to extent' checkbox
-        self.dialog.items['Scale/Zoom'].get('Restrict to extent').setCheckState(1, QtCore.Qt.Checked)
+        self.dialog.items['Scale/Zoom'].get(
+            'Restrict to extent').setCheckState(1, QtCore.Qt.Checked)
 
         self.dialog.ol3.click()
 
@@ -2270,8 +2343,9 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.assertEqual(writer.visible, [True])
         self.assertEqual(writer.cluster, [False])
         self.assertEqual(writer.popup,
-                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                         [OrderedDict(
+                             [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                              (u'NAME', u'no label'), (u'USE', u'no label')])
                           ])
         self.assertEqual(writer.json, [False])
 
@@ -2288,8 +2362,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
@@ -2321,8 +2395,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
@@ -2353,16 +2427,15 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_cdn.html'), 'r')
+            test_data_path(
+                'control', 'ol3_cdn.html'), 'r')
         control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
+            self.dialog.paramsTreeOL.findItems(
+                'Extent',
                         (Qt.MatchExactly | Qt.MatchRecursive))[0],
                 1).setCurrentIndex(1)
         self.setTemplate('canvas-size')
@@ -2381,6 +2454,7 @@ class qgis2web_classDialogTest(unittest.TestCase):
         outputFile = os.path.join(outputFolder, "index.html")
         assert os.path.isfile(outputFile)
 
+
 def read_output(url, path):
     """ Given a url for the index.html file of a preview or export and the
     relative path to an output file open the file and return it's contents as a
@@ -2393,7 +2467,6 @@ def read_output(url, path):
 def diff(control_output, test_output):
     """ Produce a unified diff given two strings splitting on newline """
     return '\n'.join(list(difflib.unified_diff(control_output.split('\n'), test_output.split('\n'), lineterm='')))
-
 
 
 if __name__ == "__main__":

--- a/test/test_qgis2web_dialog.py
+++ b/test/test_qgis2web_dialog.py
@@ -30,7 +30,6 @@ from utilities import get_qgis_app, test_data_path, load_layer, load_wfs_layer
 
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 
-from test_qgis2web_exporters import qgis2web_exporterTest
 from maindialog import MainDialog
 
 
@@ -2364,6 +2363,5 @@ def diff(control_output, test_output):
 if __name__ == "__main__":
     suite = unittest.TestSuite()
     suite.addTests(unittest.makeSuite(qgis2web_classDialogTest))
-    suite.addTests(unittest.makeSuite(qgis2web_exporterTest))
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)

--- a/test/test_qgis2web_dialog.py
+++ b/test/test_qgis2web_dialog.py
@@ -15,6 +15,7 @@ __copyright__ = 'Copyright 2015, Riccardo Klinger / Geolicious'
 import unittest
 import os
 import difflib
+from collections import OrderedDict
 
 # This import is to enable SIP API V2
 # noinspection PyUnresolvedReferences
@@ -23,6 +24,7 @@ from qgis.core import QgsProject
 from qgis.core import QgsVectorLayer, QgsMapLayerRegistry, QgsCoordinateReferenceSystem
 from PyQt4 import QtCore, QtTest
 from PyQt4.QtCore import *
+from PyQt4.QtGui import (QListWidgetItem)
 from osgeo import gdal
 from PyQt4.QtGui import QDialogButtonBox, QDialog
 
@@ -33,17 +35,6 @@ from utilities import get_qgis_app, test_data_path, load_layer, load_wfs_layer
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 
 from maindialog import MainDialog
-
-
-def GDAL_COMPUTE_VERSION(maj, min, rev):
-    return maj * 1000000 + min * 10000 + rev * 100
-
-
-def isLtrRepo():
-    """
-    Returns true if using the LTR repository
-    """
-    return 'QGIS_REPO' in os.environ and os.environ["QGIS_REPO"] == "http://qgis.org/debian-ltr"
 
 class qgis2web_classDialogTest(unittest.TestCase):
     """Test most common plugin actions"""
@@ -73,6 +64,30 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         index = combo.findText(template_name)
         combo.setCurrentIndex(index)
+
+    def defaultParams(self):
+        return {'Data export': {
+                             'Mapping library location' : 'Local',
+                             'Minify GeoJSON files': False,
+                             'Exporter': 'Export to folder',
+                             'Precision': 'maintain'},
+            'Scale/Zoom': {'Min zoom level': '1',
+                           'Restrict to extent': False,
+                           'Extent': 'Fit to layers extent',
+                           'Max zoom level': '28'},
+            'Appearance': {
+                'Add address search': False,
+                'Geolocate user': False,
+                'Base layer': [],
+                'Search layer': None,
+                'Add layers list': False,
+                'Measure tool': 'None',
+                'Match project CRS': False,
+                'Template': 'full-screen',
+                'Layer search': 'None',
+                'Highlight on hover': False,
+                'Show popups on hover': False
+            }}
 
     def test01_preview_default(self):
         """Preview default - no data (OL3)"""
@@ -135,7 +150,7 @@ class qgis2web_classDialogTest(unittest.TestCase):
 #        self.dialog.buttonExport.click()
 
     def test09_Leaflet_json_pnt_single(self):
-        """Leaflet JSON point single"""
+        """Dialog test: Leaflet  JSON point single"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
 
@@ -143,14 +158,8 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         layer.loadNamedStyle(style_path)
 
-
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_json_point_single.html'), 'r')
-        control_output = control_file.read()
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -162,16 +171,22 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,[OrderedDict(
+            [('ID', 'no label'), ('fk_region', 'no label'), ('ELEV', 'no label'), ('NAME', 'no label'),
+             ('USE', 'no label')])])
+        self.assertEqual(writer.json,[False])
 
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
 
     def test10_Leaflet_wfs_pnt_single(self):
-        """Leaflet WFS point single"""
+        """Dialog test: Leaflet  WFS point single"""
         layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
         layer_style = test_data_path('style', 'point_single.qml')
         layer = load_wfs_layer(layer_url, 'point')
@@ -179,10 +194,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path('control', 'leaflet_wfs_point_single.html'), 'r')
-        control_output = control_file.read()
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
@@ -193,14 +204,20 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,[OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
+])
+        self.assertEqual(writer.json,[False])
 
     def test11_Leaflet_json_line_single(self):
-        """Leaflet JSON line single"""
+        """Dialog test: Leaflet  JSON line single"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         style_path = test_data_path('style', 'pipelines_single.qml')
         layer = load_layer(layer_path)
@@ -208,10 +225,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path('control', 'leaflet_json_line_single.html'), 'r')
-        control_output = control_file.read()
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
@@ -221,14 +234,20 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,[OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'), (u'F_CODEDESC', u'no label')])
+])
+        self.assertEqual(writer.json,[False])
 
     def test12_Leaflet_wfs_line_single(self):
-        """Leaflet WFS line single"""
+        """Dialog test: Leaflet  WFS line single"""
         layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
                      'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
                      '=broads_inspire:centreline&SRSNAME=EPSG:27700')
@@ -239,9 +258,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(
-                test_data_path('control', 'leaflet_wfs_line_single.html'), 'r')
-        control_output = control_file.read()
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -249,14 +265,21 @@ class qgis2web_classDialogTest(unittest.TestCase):
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,[OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
+])
+        self.assertEqual(writer.json,[False])
 
     def test13_Leaflet_json_poly_single(self):
-        """Leaflet JSON polygon single"""
+        """Dialog test: Leaflet  JSON polygon single"""
         layer_path = test_data_path('layer', 'lakes.shp')
         style_path = test_data_path('style', 'lakes_single.qml')
         layer = load_layer(layer_path)
@@ -265,10 +288,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_json_polygon_single.html'), 'r')
-        control_output = control_file.read()
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -277,14 +296,20 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,[OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'), (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])
+])
+        self.assertEqual(writer.json,[False])
 
     def test14_Leaflet_wfs_poly_single(self):
-        """Leaflet WFS polygon single"""
+        """Dialog test: Leaflet  WFS polygon single"""
         layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
                      'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
                      '=dnpa_inspire:con_areas&SRSNAME=EPSG:27700')
@@ -297,9 +322,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
-
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -308,14 +330,20 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,[OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'), (u'area_ha', u'no label'), (u'web_page', u'no label')])
+])
+        self.assertEqual(writer.json,[False])
 
     def test15_Leaflet_json_pnt_categorized(self):
-        """Leaflet JSON point categorized"""
+        """Dialog test: Leaflet  JSON point categorized"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_categorized.qml')
         control_path = test_data_path(
@@ -327,9 +355,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
-
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -338,13 +363,21 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(self.dialog.previewUrl.toString().replace("file://",""))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,[OrderedDict(
+            [('ID', 'no label'), ('fk_region', 'no label'), ('ELEV', 'no label'), ('NAME', 'no label'),
+             ('USE', 'no label')])])
+        self.assertEqual(writer.json,[False])
 
     def test16_Leaflet_wfs_pnt_categorized(self):
-        """Leaflet WFS point categorized"""
+        """Dialog test: Leaflet  WFS point categorized"""
         layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
         layer_style = test_data_path('style', 'wfs_point_categorized.qml')
         control_path = test_data_path(
@@ -355,8 +388,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -364,13 +395,21 @@ class qgis2web_classDialogTest(unittest.TestCase):
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
-        test_file = open(self.dialog.previewUrl.toString().replace("file://",""))
-        test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,[OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
+])
+        self.assertEqual(writer.json,[False])
 
     def test17_Leaflet_json_line_categorized(self):
-        """Leaflet JSON line categorized"""
+        """Dialog test: Leaflet  JSON line categorized"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         style_path = test_data_path('style', 'pipelines_categorized.qml')
         control_path = test_data_path(
@@ -381,9 +420,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
-
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -391,14 +427,22 @@ class qgis2web_classDialogTest(unittest.TestCase):
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                          (u'F_CODEDESC', u'no label')])])
+        self.assertEqual(writer.json,[False])
 
     def test18_Leaflet_wfs_line_categorized(self):
-        """Leaflet WFS line categorized"""
+        """Dialog test: Leaflet  WFS line categorized"""
         layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
                      'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
                      '=broads_inspire:centreline&SRSNAME=EPSG:27700')
@@ -411,8 +455,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -421,14 +463,21 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
+])
+        self.assertEqual(writer.json,[False])
 
     def test19_Leaflet_json_poly_categorized(self):
-        """Leaflet JSON polygon categorized"""
+        """Dialog test: Leaflet  JSON polygon categorized"""
         layer_path = test_data_path('layer', 'lakes.shp')
         style_path = test_data_path('style', 'lakes_categorized.qml')
         control_path = test_data_path(
@@ -439,9 +488,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
-
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -450,29 +496,31 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])])
+        self.assertEqual(writer.json,[False])
 
     def test20_Leaflet_wfs_poly_categorized(self):
-        """Leaflet WFS polygon categorized"""
+        """Dialog test: Leaflet  WFS polygon categorized"""
         layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
                      'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
                      '=dnpa_inspire:con_areas&SRSNAME=EPSG:27700')
         layer_style = test_data_path('style', 'wfs_polygon_categorized.qml')
-        control_path = test_data_path(
-                'control', 'leaflet_wfs_polygon_categorized.html')
         layer = load_wfs_layer(layer_url, 'polygon')
         layer.loadNamedStyle(layer_style)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
-
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -480,27 +528,29 @@ class qgis2web_classDialogTest(unittest.TestCase):
                 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'), (u'area_ha', u'no label'), (u'web_page', u'no label')])
+])
+        self.assertEqual(writer.json,[False])
 
     def test21_Leaflet_json_pnt_graduated(self):
-        """Leaflet JSON point graduated"""
+        """Dialog test: Leaflet  JSON point graduated"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_graduated.qml')
-        control_path = test_data_path(
-                'control', 'leaflet_json_point_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
-
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -509,27 +559,30 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+                         )
+        self.assertEqual(writer.json,[False])
 
     def test22_Leaflet_wfs_pnt_graduated(self):
-        """Leaflet WFS point graduated"""
+        """Dialog test: Leaflet  WFS point graduated"""
         layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
         layer_style = test_data_path('style', 'wfs_point_graduated.qml')
-        control_path = test_data_path(
-                'control', 'leaflet_wfs_point_graduated.html')
         layer = load_wfs_layer(layer_url, 'point')
         layer.loadNamedStyle(layer_style)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
-
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -538,27 +591,29 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
+])
+        self.assertEqual(writer.json,[False])
 
     def test23_Leaflet_json_line_graduated(self):
-        """Leaflet JSON line graduated"""
+        """Dialog test: Leaflet  JSON line graduated"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         layer_style = test_data_path('style', 'pipelines_graduated.qml')
-        control_path = test_data_path(
-                'control', 'leaflet_json_line_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(layer_style)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
-
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -567,29 +622,32 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(self.dialog.previewUrl.toString().replace(
-                "file://",""))
-        test_output = test_file.read()
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'), (u'F_CODEDESC', u'no label')])]
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+                         )
+        self.assertEqual(writer.json,[False])
 
     def test24_Leaflet_wfs_line_graduated(self):
-        """Leaflet WFS line graduated"""
+        """Dialog test: Leaflet  WFS line graduated"""
         layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
                      'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
                      '=broads_inspire:centreline&SRSNAME=EPSG:27700')
         layer_style = test_data_path('style', 'wfs_line_graduated.qml')
-        control_path = test_data_path(
-                'control', 'leaflet_wfs_line_graduated.html')
         layer = load_wfs_layer(layer_url, 'centreline')
         layer.loadNamedStyle(layer_style)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
-
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -598,27 +656,30 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(self.dialog.previewUrl.toString().replace(
-                "file://", ""))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
+]
+                         )
+        self.assertEqual(writer.json,[False])
 
     def test25_Leaflet_json_poly_graduated(self):
-        """Leaflet JSON polygon graduated"""
+        """Dialog test: Leaflet  JSON polygon graduated"""
         layer_path = test_data_path('layer', 'lakes.shp')
         layer_style = test_data_path('style', 'lakes_graduated.qml')
-        control_path = test_data_path(
-                'control', 'leaflet_json_polygon_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(layer_style)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
-
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -627,29 +688,32 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(self.dialog.previewUrl.toString().replace(
-                "file://", ""))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+                         )
+        self.assertEqual(writer.json,[False])
 
     def test26_Leaflet_wfs_poly_graduated(self):
-        """Leaflet WFS polygon graduated"""
+        """Dialog test: Leaflet  WFS polygon graduated"""
         layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
                      'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
                      '=dnpa_inspire:con_areas&SRSNAME=EPSG:27700')
         layer_style = test_data_path('style', 'wfs_polygon_graduated.qml')
-        control_path = test_data_path(
-                'control', 'leaflet_wfs_polygon_graduated.html')
         layer = load_wfs_layer(layer_url, 'polygon')
         layer.loadNamedStyle(layer_style)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
-
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
                 self.dialog.paramsTreeOL.findItems(
@@ -658,26 +722,29 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        test_file = open(self.dialog.previewUrl.toString().replace(
-                "file://", ""))
-        test_output = test_file.read()
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,
+ [                        OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'),
+                                      (u'area_ha', u'no label'), (u'web_page', u'no label')])
+]                         )
+        self.assertEqual(writer.json,[False])
 
     def test27_OL3_pnt_single(self):
-        """OL3 point single"""
+        """Dialog test: OL3   point single"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
-        control_path = test_data_path(
-                'control', 'ol3_json_point_single.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
@@ -687,33 +754,29 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        test_style_file = open(
-                self.dialog.previewUrl.toString().replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/airports0_style.js'))
-        test_style_output = test_style_file.read()
-        test_output += test_style_output
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter ))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params,expected_params)
+        self.assertEqual(writer.groups,{})
+        self.assertEqual(writer.layers,[layer])
+        self.assertEqual(writer.visible,[True])
+        self.assertEqual(writer.cluster,[False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'), (u'NAME', u'no label'), (u'USE', u'no label')])
+]
+                         )
+        self.assertEqual(writer.json,[False])
 
     def test28_OL3_line_single(self):
-        """OL3 line single"""
+        """Dialog test: OL3   line single"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         style_path = test_data_path('style', 'pipelines_single.qml')
-        control_path = test_data_path(
-                'control', 'ol3_json_line_single.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
@@ -723,33 +786,29 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        test_style_file = open(
-                self.dialog.previewUrl.toString().replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/pipelines0_style.js'))
-        test_style_output = test_style_file.read()
-        test_output += test_style_output
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                                       (u'F_CODEDESC', u'no label')])]
+                         )
+        self.assertEqual(writer.json, [False])
 
     def test29_OL3_poly_single(self):
-        """OL3 polygon single"""
+        """Dialog test: OL3   polygon single"""
         layer_path = test_data_path('layer', 'lakes.shp')
         style_path = test_data_path('style', 'lakes_single.qml')
-        control_path = test_data_path(
-                'control', 'ol3_json_polygon_single.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
@@ -757,34 +816,29 @@ class qgis2web_classDialogTest(unittest.TestCase):
                                                  Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
-
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        test_style_file = open(
-                self.dialog.previewUrl.toString().replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/lakes0_style.js'))
-        test_style_output = test_style_file.read()
-        test_output += test_style_output
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+                         )
+        self.assertEqual(writer.json, [False])
 
     def test30_OL3_pnt_categorized(self):
-        """OL3 point categorized"""
+        """Dialog test: OL3   point categorized"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_categorized.qml')
-        control_path = test_data_path(
-                'control', 'ol3_json_point_categorized.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(
@@ -794,33 +848,29 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        test_style_file = open(
-                self.dialog.previewUrl.toString().replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/airports0_style.js'))
-        test_style_output = test_style_file.read()
-        test_output += test_style_output
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+                         )
+        self.assertEqual(writer.json, [False])
 
     def test31_OL3_line_categorized(self):
-        """OL3 line categorized"""
+        """Dialog test: OL3   line categorized"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         style_path = test_data_path('style', 'pipelines_categorized.qml')
-        control_path = test_data_path(
-                'control', 'ol3_json_line_categorized.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
@@ -828,34 +878,29 @@ class qgis2web_classDialogTest(unittest.TestCase):
                                                  Qt.MatchRecursive))[0], 1).setCurrentIndex(1)
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
-
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        test_style_file = open(
-                self.dialog.previewUrl.toString().replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/pipelines0_style.js'))
-        test_style_output = test_style_file.read()
-        test_output += test_style_output
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                                       (u'F_CODEDESC', u'no label')])]
+                         )
+        self.assertEqual(writer.json, [False])
 
     def test32_OL3_poly_categorized(self):
-        """OL3 polygon categorized"""
+        """Dialog test: OL3   polygon categorized"""
         layer_path = test_data_path('layer', 'lakes.shp')
         style_path = test_data_path('style', 'lakes_categorized.qml')
-        control_path = test_data_path(
-                'control', 'ol3_json_polygon_categorized.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
@@ -864,33 +909,29 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        test_style_file = open(
-                self.dialog.previewUrl.toString().replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/lakes0_style.js'))
-        test_style_output = test_style_file.read()
-        test_output += test_style_output
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+                         )
+        self.assertEqual(writer.json, [False])
 
     def test33_OL3_pnt_graduated(self):
-        """OL3 point graduated"""
+        """Dialog test: OL3   point graduated"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_graduated.qml')
-        control_path = test_data_path(
-                'control', 'ol3_json_point_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
@@ -899,33 +940,29 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        test_style_file = open(
-                self.dialog.previewUrl.toString().replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/airports0_style.js'))
-        test_style_output = test_style_file.read()
-        test_output += test_style_output
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+                         )
+        self.assertEqual(writer.json, [False])
 
     def test34_OL3_line_graduated(self):
-        """OL3 line graduated"""
+        """Dialog test: OL3   line graduated"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         style_path = test_data_path('style', 'pipelines_graduated.qml')
-        control_path = test_data_path(
-                'control', 'ol3_json_line_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
@@ -934,33 +971,29 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        test_style_file = open(
-                self.dialog.previewUrl.toString().replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/pipelines0_style.js'))
-        test_style_output = test_style_file.read()
-        test_output += test_style_output
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                                       (u'F_CODEDESC', u'no label')])]
+                         )
+        self.assertEqual(writer.json, [False])
 
     def test35_OL3_poly_graduated(self):
-        """OL3 polygon graduated"""
+        """Dialog test: OL3   polygon graduated"""
         layer_path = test_data_path('layer', 'lakes.shp')
         style_path = test_data_path('style', 'lakes_graduated.qml')
-        control_path = test_data_path(
-                'control', 'ol3_json_polygon_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(control_path, 'r')
-        control_output = control_file.read()
 
         self.dialog = MainDialog(IFACE)
         self.dialog.paramsTreeOL.itemWidget(self.dialog.paramsTreeOL.findItems("Extent",
@@ -969,21 +1002,22 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.ol3.click()
 
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        test_style_file = open(
-                self.dialog.previewUrl.toString().replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/lakes0_style.js'))
-        test_style_output = test_style_file.read()
-        test_output += test_style_output
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+                         )
+        self.assertEqual(writer.json, [False])
 
     def test36_OL3_layer_list(self):
-        """OL3 A layer list is present when selected"""
+        """Dialog test: OL3   A layer list is present when selected"""
 
         layer_path = test_data_path('layer', 'airports.shp')
         layer = load_layer(layer_path)
@@ -999,17 +1033,25 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Check the 'Add layers list' checkbox
         dialog.items['Appearance'].get('Add layers list').setCheckState(1, QtCore.Qt.Checked)
 
-        # Update preview
-        dialog.previewMap()
+        writer = dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Add layers list'] = True
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        expected_params['Scale/Zoom']['Extent'] = 'Canvas extent'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'), (u'NAME', u'no label'), (u'USE', u'no label')])
+])
+        self.assertEqual(writer.json, [False])
 
-        test_qgis2web_output = read_output(dialog.previewUrl.toString(), 'resources/qgis2web.js')
-        assert 'new ol.control.LayerSwitcher' in test_qgis2web_output
-
-        test_layers_output = read_output(dialog.previewUrl.toString(), 'layers/layers.js')
-        assert 'title: "airports"' in test_layers_output
 
     def test37_OL3_base_layers_have_type_base(self):
-        """OL3 Ensure base layers have a type property with a value of 'base'"""
+        """Dialog test: OL3   Ensure base layers have a type property with a value of 'base'"""
 
         layer_path = test_data_path('layer', 'airports.shp')
         layer = load_layer(layer_path)
@@ -1025,14 +1067,12 @@ class qgis2web_classDialogTest(unittest.TestCase):
         # Select a base map
         dialog.basemaps.item(0).setSelected(True)
 
-        # update preview
-        dialog.previewMap()
-
-        test_layers_output = read_output(dialog.previewUrl.toString(), 'layers/layers.js')
-        assert "'type': 'base'" in test_layers_output
+        writer = dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        self.assertEqual(writer.params['Appearance']['Base layer'],['OSM'])
 
     def test39_OL3_base_group_only_included_when_base_map_selected(self):
-        """OL3 Only include the 'Base maps' group when +1 base maps are selected"""
+        """Dialog test: OL3   Only include the 'Base maps' group when +1 base maps are selected"""
 
         layer_path = test_data_path('layer', 'airports.shp')
         layer = load_layer(layer_path)
@@ -1049,24 +1089,19 @@ class qgis2web_classDialogTest(unittest.TestCase):
         for i in range(dialog.basemaps.count()):
             dialog.basemaps.item(i).setSelected(False)
 
-        # update preview
-        dialog.previewMap()
-
-        test_layers_output = read_output(dialog.previewUrl.toString(), 'layers/layers.js')
-        assert "new ol.layer.Group" not in test_layers_output
+        writer = dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        self.assertEqual(len(writer.params['Appearance']['Base layer']),0)
 
         # Select a base map
         dialog.basemaps.item(0).setSelected(True)
 
-        # update preview
-        dialog.previewMap()
-
-        test_layers_output = read_output(dialog.previewUrl.toString(), 'layers/layers.js')
-        assert "new ol.layer.Group" in test_layers_output
-
+        writer = dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        self.assertEqual(writer.params['Appearance']['Base layer'],['OSM'])
 
     def test40_Leaflet_scalebar(self):
-        """Leaflet scale bar"""
+        """Dialog test: Leaflet  scale bar"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1074,12 +1109,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_scalebar.html'), 'r')
-        control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -1094,17 +1123,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
 
-        # Compare with control file
-
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test41_OL3_scalebar(self):
-        """OL3 scale bar"""
+        """Dialog test: OL3   scale bar"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1132,17 +1167,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         QgsProject.instance().writeEntryBool("ScaleBar", "/Enabled", True)
         self.dialog.ol3.click()
 
-        # Reset scale bar setting
-        QgsProject.instance().writeEntryBool("ScaleBar", "/Enabled", False)
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'resources/qgis2web.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test42_Leaflet_measure(self):
-        """Leaflet measure"""
+        """Dialog test: Leaflet  measure"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1150,12 +1191,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_measure.html'), 'r')
-        control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -1174,17 +1209,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Measure tool'] = 'Metric'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
 
     def test43_OL3_measure(self):
-        """OL3 measure control"""
+        """Dialog test: OL3   measure control"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1210,31 +1252,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
                 1).setCurrentIndex(1)
         self.dialog.ol3.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_measure.html'), 'r')
-        control_output = control_file.read()
-
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'index.html')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_measure.js'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'resources/qgis2web.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Measure tool'] = 'Metric'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test44_Leaflet_address(self):
-        """Leaflet address search"""
+        """Dialog test: Leaflet  address search"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1242,12 +1276,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_address.html'), 'r')
-        control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -1262,16 +1290,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Add address search'] = True
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test45_OL3_address(self):
-        """OL3 address search"""
+        """Dialog test: OL3   address search"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1293,31 +1328,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.items['Appearance'].get('Add address search').setCheckState(1, QtCore.Qt.Checked)
         self.dialog.ol3.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_address.html'), 'r')
-        control_output = control_file.read()
-
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'index.html')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_address.js'), 'r')
-        control_output = control_file.read()
-
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'resources/qgis2web.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Add address search'] = True
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test46_Leaflet_geolocate(self):
-        """Leaflet geolocate user"""
+        """Dialog test: Leaflet  geolocate user"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1325,12 +1352,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_geolocate.html'), 'r')
-        control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -1345,16 +1366,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Geolocate user'] = True
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test47_OL3_geolocate(self):
-        """OL3 geolocate user"""
+        """Dialog test: OL3   geolocate user"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1376,20 +1404,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.items['Appearance'].get('Geolocate user').setCheckState(1, QtCore.Qt.Checked)
         self.dialog.ol3.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_geolocate.js'), 'r')
-        control_output = control_file.read()
-
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'resources/qgis2web.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Geolocate user'] = True
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test48_Leaflet_highlight(self):
-        """Leaflet highlight on hover"""
+        """Dialog test: Leaflet  highlight on hover"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1397,12 +1429,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_highlight.html'), 'r')
-        control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -1417,16 +1443,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Highlight on hover'] = True
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test49_OL3_highlight(self):
-        """OL3 highlight on hover"""
+        """Dialog test: OL3   highlight on hover"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1448,20 +1481,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.items['Appearance'].get('Highlight on hover').setCheckState(1, QtCore.Qt.Checked)
         self.dialog.ol3.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_highlight.js'), 'r')
-        control_output = control_file.read()
-
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'resources/qgis2web.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Highlight on hover'] = True
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test50_Leaflet_CRS(self):
-        """Leaflet match CRS"""
+        """Dialog test: Leaflet  match CRS"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1471,12 +1508,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry.addMapLayer(layer)
         crs = QgsCoordinateReferenceSystem("EPSG:2964")
         IFACE.mapCanvas().mapRenderer().setDestinationCrs(crs)
-        
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_crs.html'), 'r')
-        control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -1491,16 +1522,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Match project CRS'] = True
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test51_OL3_CRS(self):
-        """OL3 match CRS"""
+        """Dialog test: OL3   match CRS"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1524,33 +1562,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
                 # Check the 'Match project CRS' checkbox
         self.dialog.items['Appearance'].get('Match project CRS').setCheckState(1, QtCore.Qt.Checked)
         self.dialog.ol3.click()
-
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_crs.html'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_crs.js'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'layers/layers.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Match project CRS'] = True
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test52_Leaflet_layerslist(self):
-        """Leaflet add layers list"""
+        """Dialog test: Leaflet  add layers list"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1558,12 +1586,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_layerslist.html'), 'r')
-        control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -1578,16 +1600,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Add layers list'] = True
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test53_Leaflet_visible(self):
-        """Leaflet visible"""
+        """Dialog test: Leaflet  visible"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1595,12 +1624,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_visible.html'), 'r')
-        control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -1615,16 +1638,22 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [False])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test54_OL3_visible(self):
-        """OL3 visible"""
+        """Dialog test: OL3   visible"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1646,19 +1675,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.layers_item.child(0).visibleCheck.setChecked(False)
         self.dialog.ol3.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_visible.js'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'layers/layers.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [False])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test55_Leaflet_cluster(self):
-        """Leaflet cluster"""
+        """Dialog test: Leaflet  cluster"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1666,12 +1699,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_cluster.html'), 'r')
-        control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -1686,16 +1713,22 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [True])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test56_OL3_cluster(self):
-        """OL3 cluster"""
+        """Dialog test: OL3   cluster"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1717,20 +1750,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.layers_item.child(0).clusterCheck.setChecked(True)
         self.dialog.ol3.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_cluster.js'), 'r')
-        control_output = control_file.read()
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [True])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'layers/layers.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-
-    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
     def test62_leaflet_precision(self):
-        """Leaflet precision"""
+        """Dialog test: Leaflet  precision"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1752,20 +1788,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('canvas-size')
         self.dialog.leaflet.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_precision.js'), 'r')
-        control_output = control_file.read()
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        expected_params['Data export']['Precision'] = '3'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'data/airports0.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-
-    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
     def test63_ol3_precision(self):
-        """OL3 precision"""
+        """Dialog test: OL3   precision"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1787,19 +1827,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.items['Data export'].get('Precision').combo.setCurrentIndex(2)
         self.dialog.ol3.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_precision.js'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'layers/airports0.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        expected_params['Data export']['Precision'] = '2'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test64_Leaflet_cdn(self):
-        """Leaflet CDN"""
+        """Dialog test: Leaflet  CDN"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1807,12 +1852,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_cdn.html'), 'r')
-        control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -1827,16 +1866,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.items['Data export'].get('Mapping library location').combo.setCurrentIndex(1)
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Data export']['Mapping library location'] = 'CDN'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test65_OL3_cdn(self):
-        """OL3 CDN"""
+        """Dialog test: OL3   CDN"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1844,12 +1890,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
-
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_cdn.html'), 'r')
-        control_output = control_file.read()
-
 
         # Export to web map
         self.dialog = MainDialog(IFACE)
@@ -1864,17 +1904,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.items['Data export'].get('Mapping library location').combo.setCurrentIndex(1)
         self.dialog.ol3.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Data export']['Mapping library location'] = 'CDN'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-
-    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
     def test67_leaflet_minify(self):
-        """Leaflet minify"""
+        """Dialog test: Leaflet  minify"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1899,20 +1945,25 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('canvas-size')
         self.dialog.leaflet.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_minify.js'), 'r')
-        control_output = control_file.read()
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Data export']['Precision'] = '6'
+        expected_params['Data export']['Minify GeoJSON files'] = True
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'data/airports0.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output)
-
-    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
     def test68_ol3_minify(self):
-        """OL3 minify"""
+        """Dialog test: OL3   minify"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1937,19 +1988,25 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.items['Data export'].get('Precision').combo.setCurrentIndex(2)
         self.dialog.ol3.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_minify.js'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'layers/airports0.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output)
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Data export']['Precision'] = '2'
+        expected_params['Data export']['Minify GeoJSON files'] = True
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test69_Leaflet_canvasextent(self):
-        """Leaflet canvas extent"""
+        """Dialog test: Leaflet  canvas extent"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -1969,16 +2026,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('canvas-size')
         self.dialog.leaflet.click()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Test for expected output
-        assert "}).fitBounds([[" in test_output
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Scale/Zoom']['Extent'] = 'Canvas extent'
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test70_Leaflet_maxzoom(self):
-        """Leaflet max zoom"""
+        """Dialog test: Leaflet  max zoom"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -2000,21 +2065,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_maxzoom.html'), 'r')
-        control_output = control_file.read()
 
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Scale/Zoom']['Max zoom level'] = '20'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test71_ol3_maxzoom(self):
-        """OL3 max zoom"""
+        """Dialog test: OL3   max zoom"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -2036,19 +2104,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.items['Scale/Zoom'].get('Max zoom level').combo.setCurrentIndex(19)
         self.dialog.ol3.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_maxzoom.js'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'resources/qgis2web.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Scale/Zoom']['Max zoom level'] = '20'
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test72_Leaflet_minzoom(self):
-        """Leaflet min zoom"""
+        """Dialog test: Leaflet  min zoom"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -2070,21 +2143,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_minzoom.html'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Scale/Zoom']['Min zoom level'] = '6'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test73_ol3_minzoom(self):
-        """OL3 min zoom"""
+        """Dialog test: OL3   min zoom"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -2106,19 +2181,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.items['Scale/Zoom'].get('Min zoom level').combo.setCurrentIndex(5)
         self.dialog.ol3.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_minzoom.js'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'resources/qgis2web.js')
-
-        # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Scale/Zoom']['Min zoom level'] = '6'
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test74_Leaflet_restricttoextent(self):
-        """Leaflet restrict to extent"""
+        """Dialog test: Leaflet  restrict to extent"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -2140,21 +2220,23 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.setTemplate('full-screen')
         self.dialog.leaflet.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_restricttoextent.html'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        expected_params['Scale/Zoom']['Restrict to extent'] = True
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test75_ol3_restricttoextent(self):
-        """OL3 restrict to extent"""
+        """Dialog test: OL3   restrict to extent"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         layer = load_layer(layer_path)
@@ -2177,84 +2259,24 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog.ol3.click()
 
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'resources/qgis2web.js')
-
-        # Test for expected output
-        assert "extent: [" in test_output
-
-    @unittest.skipIf(isLtrRepo(), 'Not supported using LTR repo')
-    def test76_Leaflet_25d(self):
-        """Leaflet 2.5d"""
-        layer_path = test_data_path('layer', 'lakes.shp')
-        style_path = test_data_path('style', '25d.qml')
-        layer = load_layer(layer_path)
-        layer.loadNamedStyle(style_path)
-
-        registry = QgsMapLayerRegistry.instance()
-        registry.addMapLayer(layer)
-
-        # Export to web map
-        self.dialog = MainDialog(IFACE)
-        self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
-                        (Qt.MatchExactly | Qt.MatchRecursive))[0],
-                1).setCurrentIndex(1)
-        self.setTemplate('full-screen')
-
-        self.dialog.leaflet.click()
-
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_25d.html'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-
-    @unittest.skipIf(isLtrRepo(), 'Not supported using LTR repo')
-    def test77_OL3_25d(self):
-        """OL3 2.5d"""
-        layer_path = test_data_path('layer', 'lakes.shp')
-        style_path = test_data_path('style', '25d.qml')
-        layer = load_layer(layer_path)
-        layer.loadNamedStyle(style_path)
-
-        registry = QgsMapLayerRegistry.instance()
-        registry.addMapLayer(layer)
-
-        # Export to web map
-        self.dialog = MainDialog(IFACE)
-        self.dialog.paramsTreeOL.itemWidget(
-                self.dialog.paramsTreeOL.findItems(
-                        'Extent',
-                        (Qt.MatchExactly | Qt.MatchRecursive))[0],
-                1).setCurrentIndex(1)
-        self.setTemplate('full-screen')
-
-        self.dialog.ol3.click()
-
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_25d.html'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Scale/Zoom']['Restrict to extent'] = True
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ])
+        self.assertEqual(writer.json, [False])
 
     def test78_Leaflet_raster(self):
-        """Leaflet raster"""
+        """Dialog test: Leaflet  raster"""
         layer_path = test_data_path('layer', 'test.png')
         # style_path = test_data_path('style', '25d.qml')
         layer = load_layer(layer_path)
@@ -2274,24 +2296,20 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog.leaflet.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'leaflet_raster.html'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_file = open(
-                self.dialog.previewUrl.toString().replace('file://', ''))
-        test_output = test_file.read()
-
-        # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-        
-        # test for exported raster file
-        assert os.path.exists(self.dialog.previewUrl.toString().replace('file://', '').replace('index.html', 'data/test0.png'))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, LeafletWriter))
+        expected_params = self.defaultParams()
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict()])
+        self.assertEqual(writer.json, [False])
 
     def test79_OL3_raster(self):
-        """OL3 raster"""
+        """Dialog test: OL3 raster"""
         layer_path = test_data_path('layer', 'test.png')
         # style_path = test_data_path('style', '25d.qml')
         layer = load_layer(layer_path)
@@ -2311,19 +2329,18 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         self.dialog.ol3.click()
 
-        control_file = open(
-                test_data_path(
-                        'control', 'ol3_raster.js'), 'r')
-        control_output = control_file.read()
-
-        # Open the test file
-        test_output = read_output(self.dialog.previewUrl.toString(), 'layers/layers.js')
-
-        # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-
-        # test for exported raster file
-        assert os.path.exists(self.dialog.previewUrl.toString().replace('file://', '').replace('index.html', 'layers/test0.png'))
+        writer = self.dialog.createWriter()
+        self.assertTrue(isinstance(writer, OpenLayersWriter))
+        expected_params = self.defaultParams()
+        expected_params['Appearance']['Template'] = 'canvas-size'
+        self.assertEqual(writer.params, expected_params)
+        self.assertEqual(writer.groups, {})
+        self.assertEqual(writer.layers, [layer])
+        self.assertEqual(writer.visible, [True])
+        self.assertEqual(writer.cluster, [False])
+        self.assertEqual(writer.popup,
+                         [OrderedDict()])
+        self.assertEqual(writer.json, [False])
 
     def test99_export_folder(self):
         """Export folder"""
@@ -2376,6 +2393,7 @@ def read_output(url, path):
 def diff(control_output, test_output):
     """ Produce a unified diff given two strings splitting on newline """
     return '\n'.join(list(difflib.unified_diff(control_output.split('\n'), test_output.split('\n'), lineterm='')))
+
 
 
 if __name__ == "__main__":

--- a/test/test_qgis2web_dialog.py
+++ b/test/test_qgis2web_dialog.py
@@ -26,6 +26,8 @@ from PyQt4.QtCore import *
 from osgeo import gdal
 from PyQt4.QtGui import QDialogButtonBox, QDialog
 
+from olwriter import OpenLayersWriter
+from leafletWriter import LeafletWriter
 from utilities import get_qgis_app, test_data_path, load_layer, load_wfs_layer
 
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
@@ -81,6 +83,22 @@ class qgis2web_classDialogTest(unittest.TestCase):
 #        """Save default - no data (OL3)"""
 #        self.dialog = MainDialog(IFACE)
 #        self.dialog.buttonExport.click()
+
+    def test02_toggle_format(self):
+        """ test fetching current writer type"""
+        self.dialog = MainDialog(IFACE)
+        self.dialog.leaflet.click()
+        self.assertEqual(self.dialog.currentMapFormat(), LeafletWriter.type())
+        self.dialog.ol3.click()
+        self.assertEqual(self.dialog.currentMapFormat(), OpenLayersWriter.type())
+
+    def test02b_toggle_format_factory(self):
+        """ test fetching factory for current writer type"""
+        self.dialog = MainDialog(IFACE)
+        self.dialog.leaflet.click()
+        self.assertEqual(self.dialog.getWriterFactory(), LeafletWriter)
+        self.dialog.ol3.click()
+        self.assertEqual(self.dialog.getWriterFactory(), OpenLayersWriter)
 
     def test03_toggle_Leaflet(self):
         """Toggle to Leaflet - no data"""

--- a/test/test_qgis2web_dialog.py
+++ b/test/test_qgis2web_dialog.py
@@ -1050,20 +1050,20 @@ class qgis2web_classDialogTest(unittest.TestCase):
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
-        dialog = MainDialog(IFACE)
+        self.dialog = MainDialog(IFACE)
 
         # Ensure the OpenLayers 3 option is selected
-        dialog.ol3.click()
+        self.dialog.ol3.click()
 
         # Check the 'Add layers list' checkbox
-        dialog.items['Appearance'].get(
+        self.dialog.items['Appearance'].get(
             'Add layers list').setCheckState(1, QtCore.Qt.Checked)
+        self.setTemplate('full-screen')
 
-        writer = dialog.createWriter()
+        writer = self.dialog.createWriter()
         self.assertTrue(isinstance(writer, OpenLayersWriter))
         expected_params = self.defaultParams()
         expected_params['Appearance']['Add layers list'] = True
-        expected_params['Appearance']['Template'] = 'canvas-size'
         expected_params['Scale/Zoom']['Extent'] = 'Canvas extent'
         self.assertEqual(writer.params, expected_params)
         self.assertEqual(writer.groups, {})

--- a/test/test_qgis2web_exporters.py
+++ b/test/test_qgis2web_exporters.py
@@ -243,6 +243,42 @@ class qgis2web_exporterTest(unittest.TestCase):
         content = open(expected_index_file,'r').readlines()
         self.assertEqual(content,['test2'])
 
+    def test10_FtpUploadSubfolder(self):
+        e = FtpExporter()
+        e.host = 'localhost'
+        e.port = TEST_PORT
+        e.username = 'testuser'
+        e.password = 'pw'
+
+        # copy some files to export directory
+        export_folder = e.exportDirectory()
+        try:
+            os.makedirs(export_folder)
+        except:
+            self.assertTrue(False, 'could not create export directory')
+        out_file = os.path.join(export_folder,'index.html')
+        with open(out_file,'w') as i:
+            i.write('test')
+        sub_folder=os.path.join(export_folder,'sub')
+        try:
+            os.makedirs(sub_folder)
+        except:
+            self.assertTrue(False, 'could not create export directory')
+        sub_folder_out_file = os.path.join(sub_folder,'index.html')
+        with open(sub_folder_out_file,'w') as i:
+            i.write('test2')
+
+        e.postProcess(out_file)
+
+        expected_index_file = os.path.join(FTP_USER_FOLDER,'public_html','index.html')
+        self.assertTrue(os.path.exists(expected_index_file))
+        content = open(expected_index_file,'r').readlines()
+        self.assertEqual(content,['test'])
+        expected_sub_folder_index_file = os.path.join(FTP_USER_FOLDER, 'public_html', 'sub', 'index.html')
+        self.assertTrue(os.path.exists(expected_sub_folder_index_file))
+        content = open(expected_sub_folder_index_file, 'r').readlines()
+        self.assertEqual(content, ['test2'])
+
 
 
 

--- a/test/test_qgis2web_exporters.py
+++ b/test/test_qgis2web_exporters.py
@@ -48,10 +48,11 @@ from exporter import (FolderExporter,
 
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 
-TEST_PORT=3232
+TEST_PORT = 3232
 FTP_FOLDER = ''
 FTP_USER_FOLDER = ''
 SERVER_RUNNING = False
+
 
 def createServer():
     """
@@ -104,6 +105,7 @@ def createServer():
 
 
 class qgis2web_exporterTest(unittest.TestCase):
+
     """Test exporters and exporter registry"""
 
     def setUp(self):
@@ -131,7 +133,7 @@ class qgis2web_exporterTest(unittest.TestCase):
         """Test folder exporter post processing"""
         e = FolderExporter()
         e.postProcess('/tmp/file.htm')
-        self.assertEqual(e.destinationUrl(),'/tmp/file.htm')
+        self.assertEqual(e.destinationUrl(), '/tmp/file.htm')
 
     def test03_FolderExporterSaveReadFromProject(self):
         """Test saving and restoring folder exporter settings in project"""
@@ -142,7 +144,7 @@ class qgis2web_exporterTest(unittest.TestCase):
         restored = FolderExporter()
         restored.readFromProject()
 
-        self.assertEqual(restored.exportDirectory(),'/my_folder')
+        self.assertEqual(restored.exportDirectory(), '/my_folder')
 
     def test04_RegistryHasExporters(self):
         """test that exporter registry is populated with exporters"""
@@ -155,29 +157,29 @@ class qgis2web_exporterTest(unittest.TestCase):
         EXPORTER_REGISTRY.writeToProject(e)
 
         restored = EXPORTER_REGISTRY.createFromProject()
-        self.assertEqual(type(restored),FolderExporter)
+        self.assertEqual(type(restored), FolderExporter)
         self.assertEqual(restored.exportDirectory(), '/my_folder')
 
         # try with a non-folder exporter
         f = FtpExporter()
         EXPORTER_REGISTRY.writeToProject(f)
         restored = EXPORTER_REGISTRY.createFromProject()
-        self.assertEqual(type(restored),FtpExporter)
+        self.assertEqual(type(restored), FtpExporter)
 
     def test06_FtpConfigurationDialog(self):
         """Test behavior of the FTP export configuration dialog"""
         dlg = FtpConfigurationDialog()
         # should default to port 21
-        self.assertEqual(dlg.port(),21)
+        self.assertEqual(dlg.port(), 21)
         # test getters and setters
         dlg.setHost('myhost')
-        self.assertEqual(dlg.host(),'myhost')
+        self.assertEqual(dlg.host(), 'myhost')
         dlg.setUsername('super')
-        self.assertEqual(dlg.username(),'super')
+        self.assertEqual(dlg.username(), 'super')
         dlg.setPort(54)
-        self.assertEqual(dlg.port(),54)
+        self.assertEqual(dlg.port(), 54)
         dlg.setFolder('folder')
-        self.assertEqual(dlg.folder(),'folder')
+        self.assertEqual(dlg.folder(), 'folder')
 
         # try setting port to a non-int
         dlg.setPort('a')
@@ -195,10 +197,10 @@ class qgis2web_exporterTest(unittest.TestCase):
         restored = FtpExporter()
         restored.readFromProject()
 
-        self.assertEqual(restored.host,'geocities.com')
-        self.assertEqual(restored.username,'sup3Raw3s0m64')
-        self.assertEqual(restored.remote_folder,'test_folder')
-        self.assertEqual(restored.port,123)
+        self.assertEqual(restored.host, 'geocities.com')
+        self.assertEqual(restored.username, 'sup3Raw3s0m64')
+        self.assertEqual(restored.remote_folder, 'test_folder')
+        self.assertEqual(restored.port, 123)
 
     def test08_FtpExporterTempFolder(self):
         """Test FTP exporter generation of temp folder"""
@@ -224,24 +226,25 @@ class qgis2web_exporterTest(unittest.TestCase):
             os.makedirs(export_folder)
         except:
             self.assertTrue(False, 'could not create export directory')
-        out_file = os.path.join(export_folder,'index.html')
-        with open(out_file,'w') as i:
+        out_file = os.path.join(export_folder, 'index.html')
+        with open(out_file, 'w') as i:
             i.write('test')
 
         e.postProcess(out_file)
 
-        expected_index_file = os.path.join(FTP_USER_FOLDER,'public_html','index.html')
+        expected_index_file = os.path.join(
+            FTP_USER_FOLDER, 'public_html', 'index.html')
         self.assertTrue(os.path.exists(expected_index_file))
-        content = open(expected_index_file,'r').readlines()
-        self.assertEqual(content,['test'])
+        content = open(expected_index_file, 'r').readlines()
+        self.assertEqual(content, ['test'])
 
         # try overwriting existing file
-        with open(out_file,'w') as i:
+        with open(out_file, 'w') as i:
             i.write('test2')
         e.postProcess(out_file)
         self.assertTrue(expected_index_file)
-        content = open(expected_index_file,'r').readlines()
-        self.assertEqual(content,['test2'])
+        content = open(expected_index_file, 'r').readlines()
+        self.assertEqual(content, ['test2'])
 
     def test10_FtpUploadSubfolder(self):
         e = FtpExporter()
@@ -256,30 +259,30 @@ class qgis2web_exporterTest(unittest.TestCase):
             os.makedirs(export_folder)
         except:
             self.assertTrue(False, 'could not create export directory')
-        out_file = os.path.join(export_folder,'index.html')
-        with open(out_file,'w') as i:
+        out_file = os.path.join(export_folder, 'index.html')
+        with open(out_file, 'w') as i:
             i.write('test')
-        sub_folder=os.path.join(export_folder,'sub')
+        sub_folder = os.path.join(export_folder, 'sub')
         try:
             os.makedirs(sub_folder)
         except:
             self.assertTrue(False, 'could not create export directory')
-        sub_folder_out_file = os.path.join(sub_folder,'index.html')
-        with open(sub_folder_out_file,'w') as i:
+        sub_folder_out_file = os.path.join(sub_folder, 'index.html')
+        with open(sub_folder_out_file, 'w') as i:
             i.write('test2')
 
         e.postProcess(out_file)
 
-        expected_index_file = os.path.join(FTP_USER_FOLDER,'public_html','index.html')
+        expected_index_file = os.path.join(
+            FTP_USER_FOLDER, 'public_html', 'index.html')
         self.assertTrue(os.path.exists(expected_index_file))
-        content = open(expected_index_file,'r').readlines()
-        self.assertEqual(content,['test'])
-        expected_sub_folder_index_file = os.path.join(FTP_USER_FOLDER, 'public_html', 'sub', 'index.html')
+        content = open(expected_index_file, 'r').readlines()
+        self.assertEqual(content, ['test'])
+        expected_sub_folder_index_file = os.path.join(
+            FTP_USER_FOLDER, 'public_html', 'sub', 'index.html')
         self.assertTrue(os.path.exists(expected_sub_folder_index_file))
         content = open(expected_sub_folder_index_file, 'r').readlines()
         self.assertEqual(content, ['test2'])
-
-
 
 
 if __name__ == "__main__":

--- a/test/test_qgis2web_writers.py
+++ b/test/test_qgis2web_writers.py
@@ -47,6 +47,7 @@ def isLtrRepo():
 
 
 class qgis2web_WriterTest(unittest.TestCase):
+
     """Test writers"""
 
     def setUp(self):
@@ -60,15 +61,15 @@ class qgis2web_WriterTest(unittest.TestCase):
 
     def defaultParams(self):
         return {'Data export': {
-                             'Mapping library location' : 'Local',
+            'Mapping library location': 'Local',
                              'Minify GeoJSON files': False,
                              'Exporter': 'Export to folder',
                              'Precision': 'maintain'},
-            'Scale/Zoom': {'Min zoom level': '1',
-                           'Restrict to extent': False,
-                           'Extent': 'Fit to layers extent',
-                           'Max zoom level': '28'},
-            'Appearance': {
+                'Scale/Zoom': {'Min zoom level': '1',
+                               'Restrict to extent': False,
+                               'Extent': 'Fit to layers extent',
+                               'Max zoom level': '28'},
+                'Appearance': {
                 'Add address search': False,
                 'Geolocate user': False,
                 'Base layer': [],
@@ -80,7 +81,7 @@ class qgis2web_WriterTest(unittest.TestCase):
                 'Layer search': 'None',
                 'Highlight on hover': False,
                 'Show popups on hover': False
-            }}
+        }}
 
     def test09_Leaflet_json_pnt_single(self):
         """Leaflet JSON point single"""
@@ -91,13 +92,12 @@ class qgis2web_WriterTest(unittest.TestCase):
 
         layer.loadNamedStyle(style_path)
 
-
         registry = QgsMapLayerRegistry.instance()
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_json_point_single.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_json_point_single.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -119,11 +119,13 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test10_Leaflet_wfs_pnt_single(self):
         """Leaflet WFS point single"""
-        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
+        layer_url = (
+            'http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
         layer_style = test_data_path('style', 'point_single.qml')
         layer = load_wfs_layer(layer_url, 'point')
         layer.loadNamedStyle(layer_style)
@@ -132,7 +134,7 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path('control', 'leaflet_wfs_point_single.html'), 'r')
+            test_data_path('control', 'leaflet_wfs_point_single.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -143,7 +145,7 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.visible = [True]
         writer.cluster = [False]
         writer.popup = [OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
-]
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -152,7 +154,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test11_Leaflet_json_line_single(self):
         """Leaflet JSON line single"""
@@ -165,7 +168,7 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path('control', 'leaflet_json_line_single.html'), 'r')
+            test_data_path('control', 'leaflet_json_line_single.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -176,14 +179,15 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.visible = [True]
         writer.cluster = [False]
         writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'), (u'F_CODEDESC', u'no label')])
-]
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test12_Leaflet_wfs_line_single(self):
         """Leaflet WFS line single"""
@@ -198,7 +202,7 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path('control', 'leaflet_wfs_line_single.html'), 'r')
+            test_data_path('control', 'leaflet_wfs_line_single.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -209,14 +213,15 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.visible = [True]
         writer.cluster = [False]
         writer.popup = [OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
-]
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test13_Leaflet_json_poly_single(self):
         """Leaflet JSON polygon single"""
@@ -229,8 +234,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_json_polygon_single.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_json_polygon_single.html'), 'r')
         control_output = control_file.read()
         # Export to web map
         writer = LeafletWriter()
@@ -240,14 +245,15 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.visible = [True]
         writer.cluster = [False]
         writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'), (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])
-]
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test14_Leaflet_wfs_poly_single(self):
         """Leaflet WFS polygon single"""
@@ -256,7 +262,7 @@ class qgis2web_WriterTest(unittest.TestCase):
                      '=dnpa_inspire:con_areas&SRSNAME=EPSG:27700')
         layer_style = test_data_path('style', 'polygon_single.qml')
         control_path = test_data_path(
-                'control', 'leaflet_wfs_polygon_single.html')
+            'control', 'leaflet_wfs_polygon_single.html')
         layer = load_wfs_layer(layer_url, 'polygon')
         layer.loadNamedStyle(layer_style)
 
@@ -274,21 +280,22 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.visible = [True]
         writer.cluster = [False]
         writer.popup = [OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'), (u'area_ha', u'no label'), (u'web_page', u'no label')])
-]
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test15_Leaflet_json_pnt_categorized(self):
         """Leaflet JSON point categorized"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_categorized.qml')
         control_path = test_data_path(
-                'control', 'leaflet_json_point_categorized.html')
+            'control', 'leaflet_json_point_categorized.html')
 
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
@@ -314,14 +321,16 @@ class qgis2web_WriterTest(unittest.TestCase):
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test16_Leaflet_wfs_pnt_categorized(self):
         """Leaflet WFS point categorized"""
-        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
+        layer_url = (
+            'http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
         layer_style = test_data_path('style', 'wfs_point_categorized.qml')
         control_path = test_data_path(
-                'control', 'leaflet_wfs_point_categorized.html')
+            'control', 'leaflet_wfs_point_categorized.html')
         layer = load_wfs_layer(layer_url, 'point')
         layer.loadNamedStyle(layer_style)
 
@@ -338,21 +347,22 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.visible = [True]
         writer.cluster = [False]
         writer.popup = [OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
-]
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test17_Leaflet_json_line_categorized(self):
         """Leaflet JSON line categorized"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         style_path = test_data_path('style', 'pipelines_categorized.qml')
         control_path = test_data_path(
-                'control', 'leaflet_json_line_categorized.html')
+            'control', 'leaflet_json_line_categorized.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -369,15 +379,17 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
-                          (u'F_CODEDESC', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+             (u'F_CODEDESC', u'no label')])]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test18_Leaflet_wfs_line_categorized(self):
         """Leaflet WFS line categorized"""
@@ -386,7 +398,7 @@ class qgis2web_WriterTest(unittest.TestCase):
                      '=broads_inspire:centreline&SRSNAME=EPSG:27700')
         layer_style = test_data_path('style', 'wfs_line_categorized.qml')
         control_path = test_data_path(
-                'control', 'leaflet_wfs_line_categorized.html')
+            'control', 'leaflet_wfs_line_categorized.html')
         layer = load_wfs_layer(layer_url, 'centreline')
         layer.loadNamedStyle(layer_style)
 
@@ -403,21 +415,22 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.visible = [True]
         writer.cluster = [False]
         writer.popup = [OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
-]
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test19_Leaflet_json_poly_categorized(self):
         """Leaflet JSON polygon categorized"""
         layer_path = test_data_path('layer', 'lakes.shp')
         style_path = test_data_path('style', 'lakes_categorized.qml')
         control_path = test_data_path(
-                'control', 'leaflet_json_polygon_categorized.html')
+            'control', 'leaflet_json_polygon_categorized.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -434,15 +447,17 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
-                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+             (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test20_Leaflet_wfs_poly_categorized(self):
         """Leaflet WFS polygon categorized"""
@@ -451,7 +466,7 @@ class qgis2web_WriterTest(unittest.TestCase):
                      '=dnpa_inspire:con_areas&SRSNAME=EPSG:27700')
         layer_style = test_data_path('style', 'wfs_polygon_categorized.qml')
         control_path = test_data_path(
-                'control', 'leaflet_wfs_polygon_categorized.html')
+            'control', 'leaflet_wfs_polygon_categorized.html')
         layer = load_wfs_layer(layer_url, 'polygon')
         layer.loadNamedStyle(layer_style)
 
@@ -468,21 +483,23 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'), (u'area_ha', u'no label'), (u'web_page', u'no label')])]
+        writer.popup = [OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (
+            u'date', u'no label'), (u'area_ha', u'no label'), (u'web_page', u'no label')])]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test21_Leaflet_json_pnt_graduated(self):
         """Leaflet JSON point graduated"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_graduated.qml')
         control_path = test_data_path(
-                'control', 'leaflet_json_point_graduated.html')
+            'control', 'leaflet_json_point_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -499,21 +516,24 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test22_Leaflet_wfs_pnt_graduated(self):
         """Leaflet WFS point graduated"""
-        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
+        layer_url = (
+            'http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
         layer_style = test_data_path('style', 'wfs_point_graduated.qml')
         control_path = test_data_path(
-                'control', 'leaflet_wfs_point_graduated.html')
+            'control', 'leaflet_wfs_point_graduated.html')
         layer = load_wfs_layer(layer_url, 'point')
         layer.loadNamedStyle(layer_style)
 
@@ -531,21 +551,22 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.visible = [True]
         writer.cluster = [False]
         writer.popup = [OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
-]
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test23_Leaflet_json_line_graduated(self):
         """Leaflet JSON line graduated"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         layer_style = test_data_path('style', 'pipelines_graduated.qml')
         control_path = test_data_path(
-                'control', 'leaflet_json_line_graduated.html')
+            'control', 'leaflet_json_line_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(layer_style)
 
@@ -562,14 +583,16 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'), (u'F_CODEDESC', u'no label')])]
+        writer.popup = [
+            OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'), (u'F_CODEDESC', u'no label')])]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test24_Leaflet_wfs_line_graduated(self):
         """Leaflet WFS line graduated"""
@@ -578,7 +601,7 @@ class qgis2web_WriterTest(unittest.TestCase):
                      '=broads_inspire:centreline&SRSNAME=EPSG:27700')
         layer_style = test_data_path('style', 'wfs_line_graduated.qml')
         control_path = test_data_path(
-                'control', 'leaflet_wfs_line_graduated.html')
+            'control', 'leaflet_wfs_line_graduated.html')
         layer = load_wfs_layer(layer_url, 'centreline')
         layer.loadNamedStyle(layer_style)
 
@@ -596,21 +619,22 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.visible = [True]
         writer.cluster = [False]
         writer.popup = [OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
-]
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test25_Leaflet_json_poly_graduated(self):
         """Leaflet JSON polygon graduated"""
         layer_path = test_data_path('layer', 'lakes.shp')
         layer_style = test_data_path('style', 'lakes_graduated.qml')
         control_path = test_data_path(
-                'control', 'leaflet_json_polygon_graduated.html')
+            'control', 'leaflet_json_polygon_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(layer_style)
 
@@ -627,8 +651,9 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
-                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+             (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
 
         writer.json = [False]
 
@@ -636,7 +661,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_file = open(result)
         test_output = test_file.read()
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test26_Leaflet_wfs_poly_graduated(self):
         """Leaflet WFS polygon graduated"""
@@ -645,7 +671,7 @@ class qgis2web_WriterTest(unittest.TestCase):
                      '=dnpa_inspire:con_areas&SRSNAME=EPSG:27700')
         layer_style = test_data_path('style', 'wfs_polygon_graduated.qml')
         control_path = test_data_path(
-                'control', 'leaflet_wfs_polygon_graduated.html')
+            'control', 'leaflet_wfs_polygon_graduated.html')
         layer = load_wfs_layer(layer_url, 'polygon')
         layer.loadNamedStyle(layer_style)
 
@@ -662,22 +688,24 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup =  [                        OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'),
-                                      (u'area_ha', u'no label'), (u'web_page', u'no label')])
-]
+        writer.popup = [OrderedDict(
+            [(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'),
+             (u'area_ha', u'no label'), (u'web_page', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
         test_file = open(result)
         test_output = test_file.read()
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test27_OL3_pnt_single(self):
         """OL3 point single"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_single.qml')
         control_path = test_data_path(
-                'control', 'ol3_json_point_single.html')
+            'control', 'ol3_json_point_single.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -694,8 +722,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup =  [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'), (u'NAME', u'no label'), (u'USE', u'no label')])
-]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'), (u'NAME', u'no label'), (u'USE', u'no label')])
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -703,20 +731,21 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         test_style_file = open(
-                result.replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/airports0_style.js'))
+            result.replace(
+                'file://', '').replace(
+                    'index.html', 'styles/airports0_style.js'))
         test_style_output = test_style_file.read()
         test_output += test_style_output
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test28_OL3_line_single(self):
         """OL3 line single"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         style_path = test_data_path('style', 'pipelines_single.qml')
         control_path = test_data_path(
-                'control', 'ol3_json_line_single.html')
+            'control', 'ol3_json_line_single.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -733,8 +762,9 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
-                                       (u'F_CODEDESC', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+             (u'F_CODEDESC', u'no label')])]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -742,20 +772,21 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         test_style_file = open(
-                result.replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/pipelines0_style.js'))
+            result.replace(
+                'file://', '').replace(
+                    'index.html', 'styles/pipelines0_style.js'))
         test_style_output = test_style_file.read()
         test_output += test_style_output
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test29_OL3_poly_single(self):
         """OL3 polygon single"""
         layer_path = test_data_path('layer', 'lakes.shp')
         style_path = test_data_path('style', 'lakes_single.qml')
         control_path = test_data_path(
-                'control', 'ol3_json_polygon_single.html')
+            'control', 'ol3_json_polygon_single.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -772,8 +803,9 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
-                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+             (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
 
         writer.json = [False]
 
@@ -782,20 +814,21 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         test_style_file = open(
-                result.replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/lakes0_style.js'))
+            result.replace(
+                'file://', '').replace(
+                    'index.html', 'styles/lakes0_style.js'))
         test_style_output = test_style_file.read()
         test_output += test_style_output
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test30_OL3_pnt_categorized(self):
         """OL3 point categorized"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_categorized.qml')
         control_path = test_data_path(
-                'control', 'ol3_json_point_categorized.html')
+            'control', 'ol3_json_point_categorized.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -812,8 +845,9 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])]
 
         writer.json = [False]
 
@@ -822,20 +856,21 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         test_style_file = open(
-                result.replace(
-                        'file://', '').replace(
-                        'index.html', 'styles/airports0_style.js'))
+            result.replace(
+                'file://', '').replace(
+                    'index.html', 'styles/airports0_style.js'))
         test_style_output = test_style_file.read()
         test_output += test_style_output
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test31_OL3_line_categorized(self):
         """OL3 line categorized"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         style_path = test_data_path('style', 'pipelines_categorized.qml')
         control_path = test_data_path(
-                'control', 'ol3_json_line_categorized.html')
+            'control', 'ol3_json_line_categorized.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -852,8 +887,9 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
-                                       (u'F_CODEDESC', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+             (u'F_CODEDESC', u'no label')])]
 
         writer.json = [False]
 
@@ -862,19 +898,20 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         test_style_file = open(
-                result.replace(
-                        'index.html', 'styles/pipelines0_style.js'))
+            result.replace(
+                'index.html', 'styles/pipelines0_style.js'))
         test_style_output = test_style_file.read()
         test_output += test_style_output
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test32_OL3_poly_categorized(self):
         """OL3 polygon categorized"""
         layer_path = test_data_path('layer', 'lakes.shp')
         style_path = test_data_path('style', 'lakes_categorized.qml')
         control_path = test_data_path(
-                'control', 'ol3_json_polygon_categorized.html')
+            'control', 'ol3_json_polygon_categorized.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -891,8 +928,9 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup =  [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
-                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+             (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
 
         writer.json = [False]
 
@@ -901,18 +939,19 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         test_style_file = open(result.replace(
-                        'index.html', 'styles/lakes0_style.js'))
+            'index.html', 'styles/lakes0_style.js'))
         test_style_output = test_style_file.read()
         test_output += test_style_output
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test33_OL3_pnt_graduated(self):
         """OL3 point graduated"""
         layer_path = test_data_path('layer', 'airports.shp')
         style_path = test_data_path('style', 'airports_graduated.qml')
         control_path = test_data_path(
-                'control', 'ol3_json_point_graduated.html')
+            'control', 'ol3_json_point_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -929,8 +968,9 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])]
 
         writer.json = [False]
 
@@ -939,18 +979,19 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         test_style_file = open(result.replace(
-                        'index.html', 'styles/airports0_style.js'))
+            'index.html', 'styles/airports0_style.js'))
         test_style_output = test_style_file.read()
         test_output += test_style_output
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test34_OL3_line_graduated(self):
         """OL3 line graduated"""
         layer_path = test_data_path('layer', 'pipelines.shp')
         style_path = test_data_path('style', 'pipelines_graduated.qml')
         control_path = test_data_path(
-                'control', 'ol3_json_line_graduated.html')
+            'control', 'ol3_json_line_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -967,8 +1008,9 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
-                                       (u'F_CODEDESC', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+             (u'F_CODEDESC', u'no label')])]
 
         writer.json = [False]
 
@@ -977,18 +1019,19 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         test_style_file = open(result.replace(
-                        'index.html', 'styles/pipelines0_style.js'))
+            'index.html', 'styles/pipelines0_style.js'))
         test_style_output = test_style_file.read()
         test_output += test_style_output
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test35_OL3_poly_graduated(self):
         """OL3 polygon graduated"""
         layer_path = test_data_path('layer', 'lakes.shp')
         style_path = test_data_path('style', 'lakes_graduated.qml')
         control_path = test_data_path(
-                'control', 'ol3_json_polygon_graduated.html')
+            'control', 'ol3_json_polygon_graduated.html')
         layer = load_layer(layer_path)
         layer.loadNamedStyle(style_path)
 
@@ -1005,8 +1048,9 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
-                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+        writer.popup = [OrderedDict(
+            [(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+             (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
 
         writer.json = [False]
 
@@ -1015,11 +1059,12 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         test_style_file = open(result.replace(
-                        'index.html', 'styles/lakes0_style.js'))
+            'index.html', 'styles/lakes0_style.js'))
         test_style_output = test_style_file.read()
         test_output += test_style_output
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test36_OL3_layer_list(self):
         """OL3 A layer list is present when selected"""
@@ -1041,7 +1086,7 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.visible = [True]
         writer.cluster = [False]
         writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'), (u'NAME', u'no label'), (u'USE', u'no label')])
-]
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1113,7 +1158,6 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_layers_output = read_output(result, 'layers/layers.js')
         assert "new ol.layer.Group" in test_layers_output
 
-
     def test40_Leaflet_scalebar(self):
         """Leaflet scale bar"""
         layer_path = test_data_path('layer', 'airports.shp')
@@ -1125,8 +1169,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_scalebar.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_scalebar.html'), 'r')
         control_output = control_file.read()
 
         # Check the 'Add scale bar' checkbox
@@ -1139,9 +1183,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1152,7 +1197,8 @@ class qgis2web_WriterTest(unittest.TestCase):
 
         # Compare with control file
 
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test41_OL3_scalebar(self):
         """OL3 scale bar"""
@@ -1165,8 +1211,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_scalebar.js'), 'r')
+            test_data_path(
+                'control', 'ol3_scalebar.js'), 'r')
         control_output = control_file.read()
 
         # Check the 'Add scale bar' checkbox
@@ -1180,9 +1226,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1194,7 +1241,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = read_output(result, 'resources/qgis2web.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test42_Leaflet_measure(self):
         """Leaflet measure"""
@@ -1207,8 +1255,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_measure.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_measure.html'), 'r')
         control_output = control_file.read()
         # Export to web map
         writer = LeafletWriter()
@@ -1218,9 +1266,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1230,8 +1279,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test43_OL3_measure(self):
         """OL3 measure control"""
@@ -1251,35 +1300,37 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_measure.html'), 'r')
+            test_data_path(
+                'control', 'ol3_measure.html'), 'r')
         control_output = control_file.read()
-
 
         # Open the test file
         test_output = read_output(result, 'index.html')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_measure.js'), 'r')
+            test_data_path(
+                'control', 'ol3_measure.js'), 'r')
         control_output = control_file.read()
 
         # Open the test file
         test_output = read_output(result, 'resources/qgis2web.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test44_Leaflet_address(self):
         """Leaflet address search"""
@@ -1292,8 +1343,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_address.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_address.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -1304,9 +1355,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1316,7 +1368,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test45_OL3_address(self):
         """OL3 address search"""
@@ -1336,35 +1389,36 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_address.html'), 'r')
+            test_data_path(
+                'control', 'ol3_address.html'), 'r')
         control_output = control_file.read()
-
 
         # Open the test file
         test_output = read_output(result, 'index.html')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_address.js'), 'r')
+            test_data_path(
+                'control', 'ol3_address.js'), 'r')
         control_output = control_file.read()
-
 
         # Open the test file
         test_output = read_output(result, 'resources/qgis2web.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test46_Leaflet_geolocate(self):
         """Leaflet geolocate user"""
@@ -1377,8 +1431,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_geolocate.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_geolocate.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -1389,9 +1443,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1401,7 +1456,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test47_OL3_geolocate(self):
         """OL3 geolocate user"""
@@ -1421,24 +1477,25 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_geolocate.js'), 'r')
+            test_data_path(
+                'control', 'ol3_geolocate.js'), 'r')
         control_output = control_file.read()
-
 
         # Open the test file
         test_output = read_output(result, 'resources/qgis2web.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test48_Leaflet_highlight(self):
         """Leaflet highlight on hover"""
@@ -1451,8 +1508,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_highlight.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_highlight.html'), 'r')
         control_output = control_file.read()
         # Export to web map
         writer = LeafletWriter()
@@ -1462,9 +1519,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1474,7 +1532,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test49_OL3_highlight(self):
         """OL3 highlight on hover"""
@@ -1495,24 +1554,25 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_highlight.js'), 'r')
+            test_data_path(
+                'control', 'ol3_highlight.js'), 'r')
         control_output = control_file.read()
-
 
         # Open the test file
         test_output = read_output(result, 'resources/qgis2web.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test50_Leaflet_CRS(self):
         """Leaflet match CRS"""
@@ -1525,10 +1585,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
         crs = QgsCoordinateReferenceSystem("EPSG:2964")
         IFACE.mapCanvas().mapRenderer().setDestinationCrs(crs)
-        
+
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_crs.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_crs.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -1539,9 +1599,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1551,7 +1612,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test51_OL3_CRS(self):
         """OL3 match CRS"""
@@ -1573,16 +1635,17 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_crs.html'), 'r')
+            test_data_path(
+                'control', 'ol3_crs.html'), 'r')
         control_output = control_file.read()
 
         # Open the test file
@@ -1590,18 +1653,20 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_crs.js'), 'r')
+            test_data_path(
+                'control', 'ol3_crs.js'), 'r')
         control_output = control_file.read()
 
         # Open the test file
         test_output = read_output(result, 'layers/layers.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test52_Leaflet_layerslist(self):
         """Leaflet add layers list"""
@@ -1614,8 +1679,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_layerslist.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_layerslist.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -1626,9 +1691,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1638,7 +1704,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test53_Leaflet_visible(self):
         """Leaflet visible"""
@@ -1651,8 +1718,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_visible.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_visible.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -1662,9 +1729,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [False]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1674,7 +1742,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test54_OL3_visible(self):
         """OL3 visible"""
@@ -1694,23 +1763,25 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [False]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_visible.js'), 'r')
+            test_data_path(
+                'control', 'ol3_visible.js'), 'r')
         control_output = control_file.read()
 
         # Open the test file
         test_output = read_output(result, 'layers/layers.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test55_Leaflet_cluster(self):
         """Leaflet cluster"""
@@ -1723,8 +1794,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_cluster.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_cluster.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -1734,9 +1805,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [True]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1746,7 +1818,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test56_OL3_cluster(self):
         """OL3 cluster"""
@@ -1765,25 +1838,27 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [True]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_cluster.js'), 'r')
+            test_data_path(
+                'control', 'ol3_cluster.js'), 'r')
         control_output = control_file.read()
 
         # Open the test file
         test_output = read_output(result, 'layers/layers.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
-    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
+    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2, 0, 0), 'Test requires updating for GDAL 2.0')
     def test62_leaflet_precision(self):
         """Leaflet precision"""
         layer_path = test_data_path('layer', 'airports.shp')
@@ -1803,25 +1878,27 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [True]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                     (u'NAME', u'no label'), (u'USE', u'no label')])
-                        ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_precision.js'), 'r')
+            test_data_path(
+                'control', 'leaflet_precision.js'), 'r')
         control_output = control_file.read()
 
         # Open the test file
         test_output = read_output(result, 'data/airports0.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
-    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
+    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2, 0, 0), 'Test requires updating for GDAL 2.0')
     def test63_ol3_precision(self):
         """OL3 precision"""
         layer_path = test_data_path('layer', 'airports.shp')
@@ -1841,24 +1918,25 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [True]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                     (u'NAME', u'no label'), (u'USE', u'no label')])
-                        ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_precision.js'), 'r')
+            test_data_path(
+                'control', 'ol3_precision.js'), 'r')
         control_output = control_file.read()
 
         # Open the test file
         test_output = read_output(result, 'layers/airports0.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test64_Leaflet_cdn(self):
         """Leaflet CDN"""
@@ -1871,8 +1949,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_cdn.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_cdn.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -1883,9 +1961,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1895,7 +1974,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test65_OL3_cdn(self):
         """OL3 CDN"""
@@ -1908,8 +1988,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         registry.addMapLayer(layer)
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_cdn.html'), 'r')
+            test_data_path(
+                'control', 'ol3_cdn.html'), 'r')
         control_output = control_file.read()
 
         # Export to web map
@@ -1920,9 +2000,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -1932,9 +2013,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
-    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
+    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2, 0, 0), 'Test requires updating for GDAL 2.0')
     def test67_leaflet_minify(self):
         """Leaflet minify"""
         layer_path = test_data_path('layer', 'airports.shp')
@@ -1955,16 +2037,17 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_minify.js'), 'r')
+            test_data_path(
+                'control', 'leaflet_minify.js'), 'r')
         control_output = control_file.read()
 
         # Open the test file
@@ -1973,7 +2056,7 @@ class qgis2web_WriterTest(unittest.TestCase):
         # Compare with control file
         self.assertEqual(test_output, control_output)
 
-    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
+    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2, 0, 0), 'Test requires updating for GDAL 2.0')
     def test68_ol3_minify(self):
         """OL3 minify"""
         layer_path = test_data_path('layer', 'airports.shp')
@@ -1994,16 +2077,17 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_minify.js'), 'r')
+            test_data_path(
+                'control', 'ol3_minify.js'), 'r')
         control_output = control_file.read()
 
         # Open the test file
@@ -2030,9 +2114,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup =[OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -2062,16 +2147,17 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_maxzoom.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_maxzoom.html'), 'r')
         control_output = control_file.read()
 
         # Open the test file
@@ -2079,7 +2165,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test71_ol3_maxzoom(self):
         """OL3 max zoom"""
@@ -2100,23 +2187,25 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_maxzoom.js'), 'r')
+            test_data_path(
+                'control', 'ol3_maxzoom.js'), 'r')
         control_output = control_file.read()
 
         # Open the test file
         test_output = read_output(result, 'resources/qgis2web.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test72_Leaflet_minzoom(self):
         """Leaflet min zoom"""
@@ -2136,16 +2225,17 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_minzoom.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_minzoom.html'), 'r')
         control_output = control_file.read()
 
         # Open the test file
@@ -2153,7 +2243,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test73_ol3_minzoom(self):
         """OL3 min zoom"""
@@ -2174,23 +2265,25 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_minzoom.js'), 'r')
+            test_data_path(
+                'control', 'ol3_minzoom.js'), 'r')
         control_output = control_file.read()
 
         # Open the test file
         test_output = read_output(result, 'resources/qgis2web.js')
 
         # Compare with control file
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test74_Leaflet_restricttoextent(self):
         """Leaflet restrict to extent"""
@@ -2210,16 +2303,17 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_restricttoextent.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_restricttoextent.html'), 'r')
         control_output = control_file.read()
 
         # Open the test file
@@ -2227,7 +2321,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test75_ol3_restricttoextent(self):
         """OL3 restrict to extent"""
@@ -2248,9 +2343,10 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
-                                       (u'NAME', u'no label'), (u'USE', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+             (u'NAME', u'no label'), (u'USE', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
@@ -2280,14 +2376,14 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.visible = [True]
         writer.cluster = [False]
         writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'), (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])
-]
+                        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_25d.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_25d.html'), 'r')
         control_output = control_file.read()
 
         # Open the test file
@@ -2295,7 +2391,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     @unittest.skipIf(isLtrRepo(), 'Not supported using LTR repo')
     def test77_OL3_25d(self):
@@ -2315,16 +2412,17 @@ class qgis2web_WriterTest(unittest.TestCase):
         writer.layers = [layer]
         writer.visible = [True]
         writer.cluster = [False]
-        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
-                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])
-                          ]
+        writer.popup = [OrderedDict(
+            [(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+             (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])
+        ]
         writer.json = [False]
 
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_25d.html'), 'r')
+            test_data_path(
+                'control', 'ol3_25d.html'), 'r')
         control_output = control_file.read()
 
         # Open the test file
@@ -2332,7 +2430,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
     def test78_Leaflet_raster(self):
         """Leaflet raster"""
@@ -2357,8 +2456,8 @@ class qgis2web_WriterTest(unittest.TestCase):
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'leaflet_raster.html'), 'r')
+            test_data_path(
+                'control', 'leaflet_raster.html'), 'r')
         control_output = control_file.read()
 
         # Open the test file
@@ -2366,8 +2465,9 @@ class qgis2web_WriterTest(unittest.TestCase):
         test_output = test_file.read()
 
         # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
-        
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
+
         # test for exported raster file
         assert os.path.exists(result.replace('index.html', 'data/test0.png'))
 
@@ -2394,15 +2494,16 @@ class qgis2web_WriterTest(unittest.TestCase):
         result = writer.write(IFACE, tempFolder())
 
         control_file = open(
-                test_data_path(
-                        'control', 'ol3_raster.js'), 'r')
+            test_data_path(
+                'control', 'ol3_raster.js'), 'r')
         control_output = control_file.read()
 
         # Open the test file
         test_output = read_output(result, 'layers/layers.js')
 
         # Test for expected output
-        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        self.assertEqual(
+            test_output, control_output, diff(control_output, test_output))
 
         # test for exported raster file
         assert os.path.exists(result.replace('index.html', 'layers/test0.png'))

--- a/test/test_qgis2web_writers.py
+++ b/test/test_qgis2web_writers.py
@@ -1,0 +1,2429 @@
+# coding=utf-8
+"""Writers test.
+
+.. note:: This program is free software; you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation; either version 2 of the License, or
+     (at your option) any later version.
+
+"""
+
+__author__ = 'riccardo.klinger@geolicious.de'
+__date__ = '2015-03-26'
+__copyright__ = 'Copyright 2015, Riccardo Klinger / Geolicious'
+
+import unittest
+import os
+import difflib
+from collections import OrderedDict
+
+# This import is to enable SIP API V2
+# noinspection PyUnresolvedReferences
+import qgis  # pylint: disable=unused-import
+from qgis.core import QgsProject
+from qgis.core import (QgsMapLayerRegistry,
+                       QgsCoordinateReferenceSystem)
+from PyQt4 import QtCore
+from PyQt4.QtCore import *
+from olwriter import OpenLayersWriter
+from leafletWriter import LeafletWriter
+from utils import tempFolder
+
+from osgeo import gdal
+from utilities import get_qgis_app, test_data_path, load_layer, load_wfs_layer
+
+QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
+
+
+def GDAL_COMPUTE_VERSION(maj, min, rev):
+    return maj * 1000000 + min * 10000 + rev * 100
+
+
+def isLtrRepo():
+    """
+    Returns true if using the LTR repository
+    """
+    return 'QGIS_REPO' in os.environ and os.environ["QGIS_REPO"] == "http://qgis.org/debian-ltr"
+
+
+class qgis2web_WriterTest(unittest.TestCase):
+    """Test writers"""
+
+    def setUp(self):
+        """Runs before each test"""
+        QgsProject.instance().writeEntryBool("ScaleBar", "/Enabled", False)
+
+    def tearDown(self):
+        """Runs after each test"""
+        registry = QgsMapLayerRegistry.instance()
+        registry.removeAllMapLayers()
+
+    def defaultParams(self):
+        return {'Data export': {
+                             'Mapping library location' : 'Local',
+                             'Minify GeoJSON files': False,
+                             'Exporter': 'Export to folder',
+                             'Precision': 'maintain'},
+            'Scale/Zoom': {'Min zoom level': '1',
+                           'Restrict to extent': False,
+                           'Extent': 'Fit to layers extent',
+                           'Max zoom level': '28'},
+            'Appearance': {
+                'Add address search': False,
+                'Geolocate user': False,
+                'Base layer': [],
+                'Search layer': None,
+                'Add layers list': False,
+                'Measure tool': 'None',
+                'Match project CRS': False,
+                'Template': 'full-screen',
+                'Layer search': 'None',
+                'Highlight on hover': False,
+                'Show popups on hover': False
+            }}
+
+    def test09_Leaflet_json_pnt_single(self):
+        """Leaflet JSON point single"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+
+        layer = load_layer(layer_path)
+
+        layer.loadNamedStyle(style_path)
+
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_json_point_single.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict(
+            [('ID', 'no label'), ('fk_region', 'no label'), ('ELEV', 'no label'), ('NAME', 'no label'),
+             ('USE', 'no label')])]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test10_Leaflet_wfs_pnt_single(self):
+        """Leaflet WFS point single"""
+        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
+        layer_style = test_data_path('style', 'point_single.qml')
+        layer = load_wfs_layer(layer_url, 'point')
+        layer.loadNamedStyle(layer_style)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path('control', 'leaflet_wfs_point_single.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test11_Leaflet_json_line_single(self):
+        """Leaflet JSON line single"""
+        layer_path = test_data_path('layer', 'pipelines.shp')
+        style_path = test_data_path('style', 'pipelines_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path('control', 'leaflet_json_line_single.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'), (u'F_CODEDESC', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test12_Leaflet_wfs_line_single(self):
+        """Leaflet WFS line single"""
+        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
+                     'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
+                     '=broads_inspire:centreline&SRSNAME=EPSG:27700')
+        layer_style = test_data_path('style', 'line_single.qml')
+        layer = load_wfs_layer(layer_url, 'centreline')
+        layer.loadNamedStyle(layer_style)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path('control', 'leaflet_wfs_line_single.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test13_Leaflet_json_poly_single(self):
+        """Leaflet JSON polygon single"""
+        layer_path = test_data_path('layer', 'lakes.shp')
+        style_path = test_data_path('style', 'lakes_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_json_polygon_single.html'), 'r')
+        control_output = control_file.read()
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'), (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test14_Leaflet_wfs_poly_single(self):
+        """Leaflet WFS polygon single"""
+        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
+                     'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
+                     '=dnpa_inspire:con_areas&SRSNAME=EPSG:27700')
+        layer_style = test_data_path('style', 'polygon_single.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_wfs_polygon_single.html')
+        layer = load_wfs_layer(layer_url, 'polygon')
+        layer.loadNamedStyle(layer_style)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'), (u'area_ha', u'no label'), (u'web_page', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test15_Leaflet_json_pnt_categorized(self):
+        """Leaflet JSON point categorized"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_categorized.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_json_point_categorized.html')
+
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict(
+            [('ID', 'no label'), ('fk_region', 'no label'), ('ELEV', 'no label'), ('NAME', 'no label'),
+             ('USE', 'no label')])]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test16_Leaflet_wfs_pnt_categorized(self):
+        """Leaflet WFS point categorized"""
+        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
+        layer_style = test_data_path('style', 'wfs_point_categorized.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_wfs_point_categorized.html')
+        layer = load_wfs_layer(layer_url, 'point')
+        layer.loadNamedStyle(layer_style)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test17_Leaflet_json_line_categorized(self):
+        """Leaflet JSON line categorized"""
+        layer_path = test_data_path('layer', 'pipelines.shp')
+        style_path = test_data_path('style', 'pipelines_categorized.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_json_line_categorized.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                          (u'F_CODEDESC', u'no label')])]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test18_Leaflet_wfs_line_categorized(self):
+        """Leaflet WFS line categorized"""
+        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
+                     'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
+                     '=broads_inspire:centreline&SRSNAME=EPSG:27700')
+        layer_style = test_data_path('style', 'wfs_line_categorized.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_wfs_line_categorized.html')
+        layer = load_wfs_layer(layer_url, 'centreline')
+        layer.loadNamedStyle(layer_style)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test19_Leaflet_json_poly_categorized(self):
+        """Leaflet JSON polygon categorized"""
+        layer_path = test_data_path('layer', 'lakes.shp')
+        style_path = test_data_path('style', 'lakes_categorized.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_json_polygon_categorized.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test20_Leaflet_wfs_poly_categorized(self):
+        """Leaflet WFS polygon categorized"""
+        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
+                     'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
+                     '=dnpa_inspire:con_areas&SRSNAME=EPSG:27700')
+        layer_style = test_data_path('style', 'wfs_polygon_categorized.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_wfs_polygon_categorized.html')
+        layer = load_wfs_layer(layer_url, 'polygon')
+        layer.loadNamedStyle(layer_style)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'), (u'area_ha', u'no label'), (u'web_page', u'no label')])]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test21_Leaflet_json_pnt_graduated(self):
+        """Leaflet JSON point graduated"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_graduated.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_json_point_graduated.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test22_Leaflet_wfs_pnt_graduated(self):
+        """Leaflet WFS point graduated"""
+        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=dnpa_inspire:tpo_points&SRSNAME=EPSG:27700&BBOX=233720,53549,297567,96689')
+        layer_style = test_data_path('style', 'wfs_point_graduated.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_wfs_point_graduated.html')
+        layer = load_wfs_layer(layer_url, 'point')
+        layer.loadNamedStyle(layer_style)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'), (u'objtype', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test23_Leaflet_json_line_graduated(self):
+        """Leaflet JSON line graduated"""
+        layer_path = test_data_path('layer', 'pipelines.shp')
+        layer_style = test_data_path('style', 'pipelines_graduated.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_json_line_graduated.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(layer_style)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'), (u'F_CODEDESC', u'no label')])]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test24_Leaflet_wfs_line_graduated(self):
+        """Leaflet WFS line graduated"""
+        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
+                     'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
+                     '=broads_inspire:centreline&SRSNAME=EPSG:27700')
+        layer_style = test_data_path('style', 'wfs_line_graduated.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_wfs_line_graduated.html')
+        layer = load_wfs_layer(layer_url, 'centreline')
+        layer.loadNamedStyle(layer_style)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'objecttype', u'no label'), (u'name', u'no label'), (u'navigable', u'no label'), (u'responsibleparty', u'no label'), (u'broad', u'no label'), (u'from_', u'no label'), (u'to_', u'no label'), (u'reachid', u'no label'), (u'globalid', u'no label'), (u'route', u'no label'), (u'shape_stlength__', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test25_Leaflet_json_poly_graduated(self):
+        """Leaflet JSON polygon graduated"""
+        layer_path = test_data_path('layer', 'lakes.shp')
+        layer_style = test_data_path('style', 'lakes_graduated.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_json_polygon_graduated.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(layer_style)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test26_Leaflet_wfs_poly_graduated(self):
+        """Leaflet WFS polygon graduated"""
+        layer_url = ('http://balleter.nationalparks.gov.uk/geoserver/wfs?'
+                     'SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME'
+                     '=dnpa_inspire:con_areas&SRSNAME=EPSG:27700')
+        layer_style = test_data_path('style', 'wfs_polygon_graduated.qml')
+        control_path = test_data_path(
+                'control', 'leaflet_wfs_polygon_graduated.html')
+        layer = load_wfs_layer(layer_url, 'polygon')
+        layer.loadNamedStyle(layer_style)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup =  [                        OrderedDict([(u'name', u'no label'), (u'details', u'no label'), (u'date', u'no label'),
+                                      (u'area_ha', u'no label'), (u'web_page', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test27_OL3_pnt_single(self):
+        """OL3 point single"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        control_path = test_data_path(
+                'control', 'ol3_json_point_single.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup =  [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'), (u'NAME', u'no label'), (u'USE', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        test_style_file = open(
+                result.replace(
+                        'file://', '').replace(
+                        'index.html', 'styles/airports0_style.js'))
+        test_style_output = test_style_file.read()
+        test_output += test_style_output
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test28_OL3_line_single(self):
+        """OL3 line single"""
+        layer_path = test_data_path('layer', 'pipelines.shp')
+        style_path = test_data_path('style', 'pipelines_single.qml')
+        control_path = test_data_path(
+                'control', 'ol3_json_line_single.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                                       (u'F_CODEDESC', u'no label')])]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        test_style_file = open(
+                result.replace(
+                        'file://', '').replace(
+                        'index.html', 'styles/pipelines0_style.js'))
+        test_style_output = test_style_file.read()
+        test_output += test_style_output
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test29_OL3_poly_single(self):
+        """OL3 polygon single"""
+        layer_path = test_data_path('layer', 'lakes.shp')
+        style_path = test_data_path('style', 'lakes_single.qml')
+        control_path = test_data_path(
+                'control', 'ol3_json_polygon_single.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        test_style_file = open(
+                result.replace(
+                        'file://', '').replace(
+                        'index.html', 'styles/lakes0_style.js'))
+        test_style_output = test_style_file.read()
+        test_output += test_style_output
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test30_OL3_pnt_categorized(self):
+        """OL3 point categorized"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_categorized.qml')
+        control_path = test_data_path(
+                'control', 'ol3_json_point_categorized.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        test_style_file = open(
+                result.replace(
+                        'file://', '').replace(
+                        'index.html', 'styles/airports0_style.js'))
+        test_style_output = test_style_file.read()
+        test_output += test_style_output
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test31_OL3_line_categorized(self):
+        """OL3 line categorized"""
+        layer_path = test_data_path('layer', 'pipelines.shp')
+        style_path = test_data_path('style', 'pipelines_categorized.qml')
+        control_path = test_data_path(
+                'control', 'ol3_json_line_categorized.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                                       (u'F_CODEDESC', u'no label')])]
+
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        test_style_file = open(
+                result.replace(
+                        'index.html', 'styles/pipelines0_style.js'))
+        test_style_output = test_style_file.read()
+        test_output += test_style_output
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test32_OL3_poly_categorized(self):
+        """OL3 polygon categorized"""
+        layer_path = test_data_path('layer', 'lakes.shp')
+        style_path = test_data_path('style', 'lakes_categorized.qml')
+        control_path = test_data_path(
+                'control', 'ol3_json_polygon_categorized.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup =  [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        test_style_file = open(result.replace(
+                        'index.html', 'styles/lakes0_style.js'))
+        test_style_output = test_style_file.read()
+        test_output += test_style_output
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test33_OL3_pnt_graduated(self):
+        """OL3 point graduated"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_graduated.qml')
+        control_path = test_data_path(
+                'control', 'ol3_json_point_graduated.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])]
+
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        test_style_file = open(result.replace(
+                        'index.html', 'styles/airports0_style.js'))
+        test_style_output = test_style_file.read()
+        test_output += test_style_output
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test34_OL3_line_graduated(self):
+        """OL3 line graduated"""
+        layer_path = test_data_path('layer', 'pipelines.shp')
+        style_path = test_data_path('style', 'pipelines_graduated.qml')
+        control_path = test_data_path(
+                'control', 'ol3_json_line_graduated.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'LOCDESC', u'no label'), (u'F_CODE', u'no label'),
+                                       (u'F_CODEDESC', u'no label')])]
+
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        test_style_file = open(result.replace(
+                        'index.html', 'styles/pipelines0_style.js'))
+        test_style_output = test_style_file.read()
+        test_output += test_style_output
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test35_OL3_poly_graduated(self):
+        """OL3 polygon graduated"""
+        layer_path = test_data_path('layer', 'lakes.shp')
+        style_path = test_data_path('style', 'lakes_graduated.qml')
+        control_path = test_data_path(
+                'control', 'ol3_json_polygon_graduated.html')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(control_path, 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])]
+
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_file = open(result)
+        test_output = test_file.read()
+
+        test_style_file = open(result.replace(
+                        'index.html', 'styles/lakes0_style.js'))
+        test_style_output = test_style_file.read()
+        test_output += test_style_output
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test36_OL3_layer_list(self):
+        """OL3 A layer list is present when selected"""
+
+        layer_path = test_data_path('layer', 'airports.shp')
+        layer = load_layer(layer_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Add layers list'] = True
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.params['Scale/Zoom']['Extent'] = 'Canvas extent'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'), (u'NAME', u'no label'), (u'USE', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+        test_qgis2web_output = read_output(result, 'resources/qgis2web.js')
+        assert 'new ol.control.LayerSwitcher' in test_qgis2web_output
+
+        test_layers_output = read_output(result, 'layers/layers.js')
+        assert 'title: "airports"' in test_layers_output
+
+    def test37_OL3_base_layers_have_type_base(self):
+        """OL3 Ensure base layers have a type property with a value of 'base'"""
+
+        layer_path = test_data_path('layer', 'airports.shp')
+        layer = load_layer(layer_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Base layer'] = ['OSM']
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict(
+            [(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'),
+             (u'objtype', u'no label')])
+        ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        test_layers_output = read_output(result, 'layers/layers.js')
+        assert "'type': 'base'" in test_layers_output
+
+    def test39_OL3_base_group_only_included_when_base_map_selected(self):
+        """OL3 Only include the 'Base maps' group when +1 base maps are selected"""
+
+        layer_path = test_data_path('layer', 'airports.shp')
+        layer = load_layer(layer_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # no base maps
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict(
+            [(u'ref', u'no label'), (u'tpo_name', u'no label'), (u'area_ha', u'no label'), (u'digitised', u'no label'),
+             (u'objtype', u'no label')])
+        ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        test_layers_output = read_output(result, 'layers/layers.js')
+        assert "new ol.layer.Group" not in test_layers_output
+
+        # with base maps
+        writer.params['Appearance']['Base layer'] = ['OSM']
+        result = writer.write(IFACE, tempFolder())
+
+        test_layers_output = read_output(result, 'layers/layers.js')
+        assert "new ol.layer.Group" in test_layers_output
+
+
+    def test40_Leaflet_scalebar(self):
+        """Leaflet scale bar"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_scalebar.html'), 'r')
+        control_output = control_file.read()
+
+        # Check the 'Add scale bar' checkbox
+        QgsProject.instance().writeEntryBool("ScaleBar", "/Enabled", True)
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test41_OL3_scalebar(self):
+        """OL3 scale bar"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_scalebar.js'), 'r')
+        control_output = control_file.read()
+
+        # Check the 'Add scale bar' checkbox
+        QgsProject.instance().writeEntryBool("ScaleBar", "/Enabled", True)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Reset scale bar setting
+        QgsProject.instance().writeEntryBool("ScaleBar", "/Enabled", False)
+
+        # Open the test file
+        test_output = read_output(result, 'resources/qgis2web.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test42_Leaflet_measure(self):
+        """Leaflet measure"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_measure.html'), 'r')
+        control_output = control_file.read()
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Measure tool'] = 'Metric'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+
+    def test43_OL3_measure(self):
+        """OL3 measure control"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Measure tool'] = 'Metric'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_measure.html'), 'r')
+        control_output = control_file.read()
+
+
+        # Open the test file
+        test_output = read_output(result, 'index.html')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_measure.js'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_output = read_output(result, 'resources/qgis2web.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test44_Leaflet_address(self):
+        """Leaflet address search"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_address.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Add address search'] = True
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test45_OL3_address(self):
+        """OL3 address search"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Add address search'] = True
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_address.html'), 'r')
+        control_output = control_file.read()
+
+
+        # Open the test file
+        test_output = read_output(result, 'index.html')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_address.js'), 'r')
+        control_output = control_file.read()
+
+
+        # Open the test file
+        test_output = read_output(result, 'resources/qgis2web.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test46_Leaflet_geolocate(self):
+        """Leaflet geolocate user"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_geolocate.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Geolocate user'] = True
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test47_OL3_geolocate(self):
+        """OL3 geolocate user"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Geolocate user'] = True
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_geolocate.js'), 'r')
+        control_output = control_file.read()
+
+
+        # Open the test file
+        test_output = read_output(result, 'resources/qgis2web.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test48_Leaflet_highlight(self):
+        """Leaflet highlight on hover"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_highlight.html'), 'r')
+        control_output = control_file.read()
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Highlight on hover'] = True
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test49_OL3_highlight(self):
+        """OL3 highlight on hover"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Highlight on hover'] = True
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_highlight.js'), 'r')
+        control_output = control_file.read()
+
+
+        # Open the test file
+        test_output = read_output(result, 'resources/qgis2web.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test50_Leaflet_CRS(self):
+        """Leaflet match CRS"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+        crs = QgsCoordinateReferenceSystem("EPSG:2964")
+        IFACE.mapCanvas().mapRenderer().setDestinationCrs(crs)
+        
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_crs.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Match project CRS'] = True
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test51_OL3_CRS(self):
+        """OL3 match CRS"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+        crs = QgsCoordinateReferenceSystem("EPSG:2964")
+        IFACE.mapCanvas().mapRenderer().setDestinationCrs(crs)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Match project CRS'] = True
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_crs.html'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_crs.js'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_output = read_output(result, 'layers/layers.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test52_Leaflet_layerslist(self):
+        """Leaflet add layers list"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_layerslist.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Add layers list'] = True
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test53_Leaflet_visible(self):
+        """Leaflet visible"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_visible.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [False]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test54_OL3_visible(self):
+        """OL3 visible"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [False]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_visible.js'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_output = read_output(result, 'layers/layers.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test55_Leaflet_cluster(self):
+        """Leaflet cluster"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_cluster.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [True]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test56_OL3_cluster(self):
+        """OL3 cluster"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [True]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_cluster.js'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_output = read_output(result, 'layers/layers.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
+    def test62_leaflet_precision(self):
+        """Leaflet precision"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.params['Data export']['Precision'] = '3'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [True]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                     (u'NAME', u'no label'), (u'USE', u'no label')])
+                        ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_precision.js'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_output = read_output(result, 'data/airports0.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
+    def test63_ol3_precision(self):
+        """OL3 precision"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.params['Data export']['Precision'] = '2'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [True]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                     (u'NAME', u'no label'), (u'USE', u'no label')])
+                        ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_precision.js'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_output = read_output(result, 'layers/airports0.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+
+    def test64_Leaflet_cdn(self):
+        """Leaflet CDN"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_cdn.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Data export']['Mapping library location'] = 'CDN'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test65_OL3_cdn(self):
+        """OL3 CDN"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_cdn.html'), 'r')
+        control_output = control_file.read()
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Data export']['Mapping library location'] = 'CDN'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
+    def test67_leaflet_minify(self):
+        """Leaflet minify"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Data export']['Precision'] = '6'
+        writer.params['Data export']['Minify GeoJSON files'] = True
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_minify.js'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_output = read_output(result, 'data/airports0.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output)
+
+    @unittest.skipIf(gdal.VersionInfo('VERSION_NUM') >= GDAL_COMPUTE_VERSION(2,0,0), 'Test requires updating for GDAL 2.0')
+    def test68_ol3_minify(self):
+        """OL3 minify"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Data export']['Precision'] = '2'
+        writer.params['Data export']['Minify GeoJSON files'] = True
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_minify.js'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_output = read_output(result, 'layers/airports0.js')
+        # Compare with control file
+        self.assertEqual(test_output, control_output)
+
+    def test69_Leaflet_canvasextent(self):
+        """Leaflet canvas extent"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Scale/Zoom']['Extent'] = 'Canvas extent'
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup =[OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Test for expected output
+        assert "}).fitBounds([[" in test_output
+
+    def test70_Leaflet_maxzoom(self):
+        """Leaflet max zoom"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Scale/Zoom']['Max zoom level'] = '20'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_maxzoom.html'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Test for expected output
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test71_ol3_maxzoom(self):
+        """OL3 max zoom"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Scale/Zoom']['Max zoom level'] = '20'
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_maxzoom.js'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_output = read_output(result, 'resources/qgis2web.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test72_Leaflet_minzoom(self):
+        """Leaflet min zoom"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Scale/Zoom']['Min zoom level'] = '6'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_minzoom.html'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Test for expected output
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test73_ol3_minzoom(self):
+        """OL3 min zoom"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Scale/Zoom']['Min zoom level'] = '6'
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_minzoom.js'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_output = read_output(result, 'resources/qgis2web.js')
+
+        # Compare with control file
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test74_Leaflet_restricttoextent(self):
+        """Leaflet restrict to extent"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.params['Scale/Zoom']['Restrict to extent'] = True
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_restricttoextent.html'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Test for expected output
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test75_ol3_restricttoextent(self):
+        """OL3 restrict to extent"""
+        layer_path = test_data_path('layer', 'airports.shp')
+        style_path = test_data_path('style', 'airports_single.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.params['Scale/Zoom']['Restrict to extent'] = True
+        writer.params['Appearance']['Template'] = 'canvas-size'
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'ID', u'no label'), (u'fk_region', u'no label'), (u'ELEV', u'no label'),
+                                       (u'NAME', u'no label'), (u'USE', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        # Open the test file
+        test_output = read_output(result, 'resources/qgis2web.js')
+
+        # Test for expected output
+        assert "extent: [" in test_output
+
+    @unittest.skipIf(isLtrRepo(), 'Not supported using LTR repo')
+    def test76_Leaflet_25d(self):
+        """Leaflet 2.5d"""
+        layer_path = test_data_path('layer', 'lakes.shp')
+        style_path = test_data_path('style', '25d.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'), (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])
+]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_25d.html'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Test for expected output
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    @unittest.skipIf(isLtrRepo(), 'Not supported using LTR repo')
+    def test77_OL3_25d(self):
+        """OL3 2.5d"""
+        layer_path = test_data_path('layer', 'lakes.shp')
+        style_path = test_data_path('style', '25d.qml')
+        layer = load_layer(layer_path)
+        layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict([(u'cat', u'no label'), (u'NAMES', u'no label'), (u'AREA_MI', u'no label'),
+                                       (u'xlabel', u'no label'), (u'ylabel', u'no label'), (u'rotation', u'no label')])
+                          ]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_25d.html'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Test for expected output
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+    def test78_Leaflet_raster(self):
+        """Leaflet raster"""
+        layer_path = test_data_path('layer', 'test.png')
+        # style_path = test_data_path('style', '25d.qml')
+        layer = load_layer(layer_path)
+        # layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = LeafletWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict()]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'leaflet_raster.html'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_file = open(result)
+        test_output = test_file.read()
+
+        # Test for expected output
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+        
+        # test for exported raster file
+        assert os.path.exists(result.replace('index.html', 'data/test0.png'))
+
+    def test79_OL3_raster(self):
+        """OL3 raster"""
+        layer_path = test_data_path('layer', 'test.png')
+        # style_path = test_data_path('style', '25d.qml')
+        layer = load_layer(layer_path)
+        # layer.loadNamedStyle(style_path)
+
+        registry = QgsMapLayerRegistry.instance()
+        registry.addMapLayer(layer)
+
+        # Export to web map
+        writer = OpenLayersWriter()
+        writer.params = self.defaultParams()
+        writer.groups = {}
+        writer.layers = [layer]
+        writer.visible = [True]
+        writer.cluster = [False]
+        writer.popup = [OrderedDict()]
+        writer.json = [False]
+
+        result = writer.write(IFACE, tempFolder())
+
+        control_file = open(
+                test_data_path(
+                        'control', 'ol3_raster.js'), 'r')
+        control_output = control_file.read()
+
+        # Open the test file
+        test_output = read_output(result, 'layers/layers.js')
+
+        # Test for expected output
+        self.assertEqual(test_output, control_output, diff(control_output, test_output))
+
+        # test for exported raster file
+        assert os.path.exists(result.replace('index.html', 'layers/test0.png'))
+
+
+def read_output(url, path):
+    """ Given a url for the index.html file of a preview or export and the
+    relative path to an output file open the file and return it's contents as a
+    string """
+    abs_path = url.replace('file://', '').replace('index.html', path)
+    with open(abs_path) as f:
+        return f.read()
+
+
+def diff(control_output, test_output):
+    """ Produce a unified diff given two strings splitting on newline """
+    return '\n'.join(list(difflib.unified_diff(control_output.split('\n'), test_output.split('\n'), lineterm='')))
+
+
+if __name__ == "__main__":
+    suite = unittest.TestSuite()
+    suite.addTests(unittest.makeSuite(qgis2web_WriterTest))
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite)

--- a/writer.py
+++ b/writer.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Nyall Dawson (nyall.dawson@gmail.com)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from PyQt4.QtCore import (QObject)
+
+translator = QObject()
+
+
+class Writer(object):
+
+    """
+    Generic base class for web map writers. Writers generate the
+    HTML, JavaScript and collect other assets required for
+    creation of a standalone web map.
+    """
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def type(cls):
+        """
+        :return: Unique string for writer type
+        """
+        return ''
+
+    @classmethod
+    def name(cls):
+        """
+        :return: Translated, user friendly name for writer
+        """
+        return ''

--- a/writer.py
+++ b/writer.py
@@ -32,6 +32,21 @@ class Writer(object):
     def __init__(self):
         self.written_files = []
         self.preview_file = None
+        # layer groups
+        self.groups = []
+        # list of layers to write
+        self.layers = []
+        # list of whether each layer is visible
+        self.visible = []
+        # list of whether each layer should be clustered
+        self.cluster = []
+        # popup content
+        self.popup = None
+        # json content
+        self.json = None
+        # configuration dictionary (TODO - standardise
+        # between writers!)
+        self.params = {}
 
     @classmethod
     def type(cls):
@@ -47,20 +62,11 @@ class Writer(object):
         """
         return ''
 
-    def write(self, iface, groups, layers, visible, cluster, popup,
-              json, params, dest_folder):
+    def write(self, iface, dest_folder):
         """
         Writes the web map output for a specified configuation.
         :param iface: QGIS interface
-        :param groups: layer groups
-        :param layers: list of layers to write
-        :param visible: list of whether each layer is visible
-        :param cluster: list of whether each layer should be clustered
-        :param popup: popup content
-        :param json: json content
-        :param params: configuration dictionary (TODO - standardise
-        between writers!)
         :param dest_folder destination folder for writing
-        :return: True if writing was successful
+        :return: Main index file for web map
         """
-        return False
+        return ''

--- a/writer.py
+++ b/writer.py
@@ -30,7 +30,8 @@ class Writer(object):
     """
 
     def __init__(self):
-        pass
+        self.written_files = []
+        self.preview_file = None
 
     @classmethod
     def type(cls):
@@ -45,3 +46,21 @@ class Writer(object):
         :return: Translated, user friendly name for writer
         """
         return ''
+
+    def write(self, iface, groups, layers, visible, cluster, popup,
+              json, params, dest_folder):
+        """
+        Writes the web map output for a specified configuation.
+        :param iface: QGIS interface
+        :param groups: layer groups
+        :param layers: list of layers to write
+        :param visible: list of whether each layer is visible
+        :param cluster: list of whether each layer should be clustered
+        :param popup: popup content
+        :param json: json content
+        :param params: configuration dictionary (TODO - standardise
+        between writers!)
+        :param dest_folder destination folder for writing
+        :return: True if writing was successful
+        """
+        return False

--- a/writer.py
+++ b/writer.py
@@ -33,7 +33,7 @@ class Writer(object):
         self.written_files = []
         self.preview_file = None
         # layer groups
-        self.groups = []
+        self.groups = {}
         # list of layers to write
         self.layers = []
         # list of whether each layer is visible


### PR DESCRIPTION
This PR implements a bunch of refactoring in order to better separate writers and the main dialog.

- a new base class has been added for writer objects, with a common interface for writing maps. This allows removal of a lot of duplicate code
- the main dialog is now focused mostly on creating a writer object and setting the parameters for it. This separation helps keep writer logic out of the gui dialog, and will make it easier to add features like processing algorithms for web map generation at a later stage
- tests have been refactored too. I've copied and split the existing dialog test into dialog & writer tests. The dialog test ONLY checks that settings in the dialog are reflected in the writer objects created by the dialog. The writer tests perform the checks that the created web map correctly matches the writer's settings. This change makes it easier to tell if a regression is in the dialog or a writer, and allows for a cleaner separation of gui and writer logic