### PR TITLE
Refactor project saving/restoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
 script:
   - pep8 --exclude=test,exp2js.py,ui*.py ./
   - make pylint
-  - QGIS_DEBUG=0 xvfb-run --server-args="-screen 0, 1024x768x24" nosetests -s --nologcapture -A 'not slow' -v --with-coverage --verbose --cover-package=qgis2web --cover-package=maindialog --cover-package=utils --cover-package=configparams --cover-package=olwriter --cover-package=leafletWriter  --cover-package=olScriptStrings --cover-package=basemaps --cover-package=leafletFileScripts --cover-package=leafletLayerScripts --cover-package=leafletScriptStrings --cover-package=leafletStyleScripts --cover-package=exporter
+  - QGIS_DEBUG=0 xvfb-run --server-args="-screen 0, 1024x768x24" nosetests -s --nologcapture -A 'not slow' -v --with-coverage --verbose --cover-package=qgis2web --cover-package=maindialog --cover-package=utils --cover-package=configparams --cover-package=olwriter --cover-package=leafletWriter  --cover-package=olScriptStrings --cover-package=basemaps --cover-package=leafletFileScripts --cover-package=leafletLayerScripts --cover-package=leafletScriptStrings --cover-package=leafletStyleScripts --cover-package=exporter --cover-package=writerRegistry --cover-package=writer
 after_success:
   - coveralls
 

--- a/configparams.py
+++ b/configparams.py
@@ -93,6 +93,8 @@ def getDefaultParams():
                     settings[param] = value[-1]
                 else:
                     settings[param] = value[0]
+    params['Appearance']['Base layer'] = []
+    params['Appearance']['Search layer'] = None
     return params
 
 

--- a/configparams.py
+++ b/configparams.py
@@ -89,7 +89,10 @@ def getDefaultParams():
     for group, settings in params.iteritems():
         for param, value in settings.iteritems():
             if isinstance(value, tuple):
-                settings[param] = value[0]
+                if param == 'Max zoom level':
+                    settings[param] = value[-1]
+                else:
+                    settings[param] = value[0]
     return params
 
 

--- a/configparams.py
+++ b/configparams.py
@@ -40,8 +40,8 @@ def getTemplates():
                  if f.endswith("html"))
 
 
-def getParams(configure_exporter_action):
-    return {
+def getParams(configure_exporter_action=None):
+    params = {
         "Appearance": {
             "Add layers list": False,
             "Match project CRS": False,
@@ -54,8 +54,6 @@ def getParams(configure_exporter_action):
             "Template": getTemplates()
         },
         "Data export": {
-            "Exporter": {'option': EXPORTER_REGISTRY.getOptions(),
-                         'action': configure_exporter_action},
             "Precision": ("maintain", "1", "2", "3", "4", "5", "6", "7", "8",
                           "9", "10", "11", "12", "13", "14", "15"),
             "Minify GeoJSON files": True,
@@ -75,30 +73,49 @@ def getParams(configure_exporter_action):
         }
     }
 
-baselayers = (
-            "OSM",
-            "OSM B&W",
-            "Stamen Toner",
-            "OSM DE",
-            "OSM HOT",
-            "Thunderforest Cycle",
-            "Thunderforest Transport",
-            "Thunderforest Landscape",
-            "Thunderforest Outdoors",
-            "OpenMapSurfer Roads",
-            "OpenMapSurfer adminb",
-            "OpenMapSurfer roadsg",
-            "Stamen Terrain",
-            "Stamen Terrain background",
-            "Stamen Watercolor",
-            "OpenWeatherMap Clouds",
-            "OpenWeatherMap Precipitation",
-            "OpenWeatherMap Rain",
-            "OpenWeatherMap Pressure",
-            "OpenWeatherMap Wind",
-            "OpenWeatherMap Temp",
-            "OpenWeatherMap Snow"),
+    if configure_exporter_action:
+        params["Data export"]["Exporter"] = {'option':
+                                             EXPORTER_REGISTRY.getOptions(),
+                                             'action':
+                                             configure_exporter_action}
+    else:
+        params["Data export"]["Exporter"] = EXPORTER_REGISTRY.getOptions()
 
+    return params
+
+
+def getDefaultParams():
+    params = getParams()
+    for group, settings in params.iteritems():
+        for param, value in settings.iteritems():
+            if isinstance(value, tuple):
+                settings[param] = value[0]
+    return params
+
+
+baselayers = (
+                 "OSM",
+                 "OSM B&W",
+                 "Stamen Toner",
+                 "OSM DE",
+                 "OSM HOT",
+                 "Thunderforest Cycle",
+                 "Thunderforest Transport",
+                 "Thunderforest Landscape",
+                 "Thunderforest Outdoors",
+                 "OpenMapSurfer Roads",
+                 "OpenMapSurfer adminb",
+                 "OpenMapSurfer roadsg",
+                 "Stamen Terrain",
+                 "Stamen Terrain background",
+                 "Stamen Watercolor",
+                 "OpenWeatherMap Clouds",
+                 "OpenWeatherMap Precipitation",
+                 "OpenWeatherMap Rain",
+                 "OpenWeatherMap Pressure",
+                 "OpenWeatherMap Wind",
+                 "OpenWeatherMap Temp",
+                 "OpenWeatherMap Snow"),
 
 specificParams = {
 }

--- a/maindialog.py
+++ b/maindialog.py
@@ -400,8 +400,7 @@ class MainDialog(QDialog, Ui_MainDialog):
             for key in baselayers[i]:
                 attrFields.append(key)
         self.basemaps.addItems(attrFields)
-        basemaps = QgsProject.instance().readEntry("qgis2web", "Basemaps")[0]
-        for basemap in basemaps.split(","):
+        for basemap in WRITER_REGISTRY.getBasemapsFromProject():
             try:
                 self.basemaps.findItems(basemap,
                                         (Qt.MatchExactly))[0].setSelected(True)
@@ -445,9 +444,8 @@ class MainDialog(QDialog, Ui_MainDialog):
                                                  param.replace(" ", ""),
                                                  item.setting())
         EXPORTER_REGISTRY.writeToProject(self.exporter)
-        basemaps = self.basemaps.selectedItems()
-        basemaplist = ",".join(basemap.text() for basemap in basemaps)
-        QgsProject.instance().writeEntry("qgis2web", "Basemaps", basemaplist)
+        basemaps = [i.text() for i in self.basemaps.selectedItems()]
+        WRITER_REGISTRY.saveBasemapsToProject(basemaps)
         return parameters
 
     def getLayersAndGroups(self):

--- a/test/test_qgis2web_dialog.py
+++ b/test/test_qgis2web_dialog.py
@@ -31,6 +31,7 @@ from PyQt4.QtGui import QDialogButtonBox, QDialog
 from olwriter import OpenLayersWriter
 from leafletWriter import LeafletWriter
 from utilities import get_qgis_app, test_data_path, load_layer, load_wfs_layer
+from configparams import (getDefaultParams)
 
 QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
 
@@ -2453,6 +2454,34 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         outputFile = os.path.join(outputFolder, "index.html")
         assert os.path.isfile(outputFile)
+
+    def test100_setStateToParams(self):
+        """Test that setting state to match parameters works"""
+        params=getDefaultParams()
+        self.dialog.setStateToParams(params)
+
+        writer = self.dialog.createWriter()
+        self.maxDiff = 1000000000
+        # not present in config params
+        del writer.params['Appearance']['Search layer']
+        del writer.params['Appearance']['Base layer']
+        self.assertEqual(dict(writer.params),params)
+        # change some parameters (one of each type)
+        params['Appearance']['Add layers list'] = True
+        params['Data export']['Minify GeoJSON files'] = False
+        params['Data export']['Precision'] = '4'
+        params['Data export']['Mapping library location'] = 'CDN'
+        self.dialog.setStateToParams(params)
+
+        writer = self.dialog.createWriter()
+        # not present in config params
+        del writer.params['Appearance']['Search layer']
+        del writer.params['Appearance']['Base layer']
+
+        self.assertEqual(writer.params,params)
+
+
+
 
 
 def read_output(url, path):

--- a/test/test_qgis2web_dialog.py
+++ b/test/test_qgis2web_dialog.py
@@ -71,7 +71,7 @@ class qgis2web_classDialogTest(unittest.TestCase):
     def defaultParams(self):
         return {'Data export': {
             'Mapping library location': 'Local',
-                             'Minify GeoJSON files': False,
+                             'Minify GeoJSON files': True,
                              'Exporter': 'Export to folder',
                              'Precision': 'maintain'},
                 'Scale/Zoom': {'Min zoom level': '1',
@@ -2462,9 +2462,6 @@ class qgis2web_classDialogTest(unittest.TestCase):
 
         writer = self.dialog.createWriter()
         self.maxDiff = 1000000000
-        # not present in config params
-        del writer.params['Appearance']['Search layer']
-        del writer.params['Appearance']['Base layer']
         self.assertEqual(dict(writer.params),params)
         # change some parameters (one of each type)
         params['Appearance']['Add layers list'] = True
@@ -2474,11 +2471,26 @@ class qgis2web_classDialogTest(unittest.TestCase):
         self.dialog.setStateToParams(params)
 
         writer = self.dialog.createWriter()
-        # not present in config params
-        del writer.params['Appearance']['Search layer']
-        del writer.params['Appearance']['Base layer']
-
         self.assertEqual(writer.params,params)
+
+    def test101_setStateToWriter(self):
+        """Test setting state to writer works"""
+        writer = LeafletWriter()
+        writer.params = getDefaultParams()
+        # change some parameters
+        writer.params['Appearance']['Add layers list'] = True
+        writer.params['Data export']['Minify GeoJSON files'] = False
+        writer.params['Data export']['Precision'] = '4'
+        writer.params['Data export']['Mapping library location'] = 'CDN'
+
+        self.dialog.setStateToWriter(writer)
+
+        new_writer = self.dialog.createWriter()
+        self.maxDiff = 1000000000
+        self.assertTrue( isinstance(new_writer, LeafletWriter))
+        self.assertEqual(dict(new_writer.params),writer.params)
+
+
 
 
 

--- a/test/test_qgis2web_writerRegistry.py
+++ b/test/test_qgis2web_writerRegistry.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Nyall Dawson (nyall.dawson@gmail.com)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+__author__ = 'nyall.dawson@gmail.com'
+__date__ = '2017-02-15'
+__copyright__ = 'Copyright 2017, Nyall Dawson'
+
+import unittest
+
+# This import is to enable SIP API V2
+# noinspection PyUnresolvedReferences
+import qgis  # pylint: disable=unused-import
+
+from utilities import get_qgis_app
+from writerRegistry import (WRITER_REGISTRY)
+from olwriter import (OpenLayersWriter)
+from leafletWriter import (LeafletWriter)
+
+QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
+
+
+class qgis2web_writerRegistryTest(unittest.TestCase):
+
+    """Test writer registry"""
+
+    def setUp(self):
+        """Runs before each test"""
+        pass
+
+    def test01_RegistryHasExporters(self):
+        """test that writer registry is populated with writers"""
+        self.assertTrue(OpenLayersWriter in WRITER_REGISTRY.getWriters())
+
+    def test02_SaveRestoreWriterTypeFromProject(self):
+        """Test saving and restoring writer type from project"""
+        WRITER_REGISTRY.saveTypeToProject(OpenLayersWriter.type())
+        self.assertEqual(
+            WRITER_REGISTRY.getWriterFactoryFromProject(), OpenLayersWriter)
+        WRITER_REGISTRY.saveTypeToProject(LeafletWriter.type())
+        self.assertEqual(
+            WRITER_REGISTRY.getWriterFactoryFromProject(), LeafletWriter)
+
+
+if __name__ == "__main__":
+    suite = unittest.TestSuite()
+    suite.addTests(unittest.makeSuite(qgis2web_writerRegistryTest))
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite)

--- a/test/test_qgis2web_writerRegistry.py
+++ b/test/test_qgis2web_writerRegistry.py
@@ -93,6 +93,24 @@ class qgis2web_writerRegistryTest(unittest.TestCase):
         restored_params = WRITER_REGISTRY.readParamsFromProject()
         self.assertEqual(restored_params,params)
 
+    def test06_SaveRestoreWriterFromProject(self):
+        """Test saving and restoring writer state to project"""
+
+        writer = LeafletWriter()
+        writer.params = getDefaultParams()
+        # change some parameters
+        writer.params['Appearance']['Add layers list'] = True
+        writer.params['Data export']['Minify GeoJSON files'] = False
+        writer.params['Data export']['Precision'] = '4'
+        writer.params['Data export']['Mapping library location'] = 'CDN'
+        writer.params['Appearance']['Base layer'] = ['a','b','c']
+
+        WRITER_REGISTRY.saveWriterToProject(writer)
+
+        new_writer = WRITER_REGISTRY.createWriterFromProject()
+        self.assertTrue( isinstance(new_writer, LeafletWriter))
+        self.assertEqual(new_writer.params,writer.params)
+
 
 
 if __name__ == "__main__":

--- a/test/test_qgis2web_writerRegistry.py
+++ b/test/test_qgis2web_writerRegistry.py
@@ -57,11 +57,20 @@ class qgis2web_writerRegistryTest(unittest.TestCase):
         self.assertEqual(
             WRITER_REGISTRY.getWriterFactoryFromProject(), LeafletWriter)
 
+        # no existing settings
+        QgsProject.instance().removeEntry("qgis2web", "/")
+        self.assertEqual(
+            WRITER_REGISTRY.getWriterFactoryFromProject(), OpenLayersWriter)
+
     def test03_SaveRestoreBasemapsFromProject(self):
         """Test saving and restoring enabled basemaps from project"""
         self.assertEqual(WRITER_REGISTRY.getBasemapsFromProject(),[])
         WRITER_REGISTRY.saveBasemapsToProject(['a','b c d'])
         self.assertEqual(WRITER_REGISTRY.getBasemapsFromProject(),['a','b c d'])
+
+        # no existing settings
+        QgsProject.instance().removeEntry("qgis2web", "/")
+        self.assertEqual(WRITER_REGISTRY.getBasemapsFromProject(), [])
 
     def test04_SanitiseKey(self):
         """Test sanitising param key for storage"""

--- a/test/test_qgis2web_writerRegistry.py
+++ b/test/test_qgis2web_writerRegistry.py
@@ -81,6 +81,7 @@ class qgis2web_writerRegistryTest(unittest.TestCase):
         # change some parameters (one of each type)
 
         params['Appearance']['Add layers list'] = True
+        params['Data export']['Minify GeoJSON files'] = False
         # no ints in config yet!
         # params['Test']['test int'] = 5
         params['Data export']['Precision'] = '4'

--- a/test/test_qgis2web_writerRegistry.py
+++ b/test/test_qgis2web_writerRegistry.py
@@ -55,6 +55,12 @@ class qgis2web_writerRegistryTest(unittest.TestCase):
         self.assertEqual(
             WRITER_REGISTRY.getWriterFactoryFromProject(), LeafletWriter)
 
+    def test03_SaveRestoreBasemapsFromProject(self):
+        """Test saving and restoring enabled basemaps from project"""
+        self.assertEqual(WRITER_REGISTRY.getBasemapsFromProject(),[])
+        WRITER_REGISTRY.saveBasemapsToProject(['a','b c d'])
+        self.assertEqual(WRITER_REGISTRY.getBasemapsFromProject(),['a','b c d'])
+
 
 if __name__ == "__main__":
     suite = unittest.TestSuite()

--- a/writerRegistry.py
+++ b/writerRegistry.py
@@ -124,10 +124,6 @@ class WriterRegistry(object):
         project = QgsProject.instance()
         key_string = self.sanitiseKey(parameter)
 
-        if isinstance(default_value, dict):
-            action = default_value['action']
-            default_value = default_value['option']
-
         value = default_value
         if isinstance(default_value, bool):
             if project.readBoolEntry(
@@ -139,17 +135,6 @@ class WriterRegistry(object):
                     "qgis2web", key_string)[1]:
                 value = project.readNumEntry("qgis2web",
                                              key_string)[0]
-        elif isinstance(default_value, tuple):
-            if project.readEntry("qgis2web",
-                                 key_string)[1]:
-                saved_value = project.readEntry(
-                    "qgis2web", key_string)[0]
-                if saved_value in default_value:
-                    value = saved_value
-                else:
-                    value = default_value[0]
-            else:
-                value = default_value[0]
         else:
             if (isinstance(project.readEntry("qgis2web",
                                              key_string)[0],

--- a/writerRegistry.py
+++ b/writerRegistry.py
@@ -177,6 +177,28 @@ class WriterRegistry(object):
 
         return read_params
 
+    def createWriterFromProject(self):
+        """
+        Creates a writer matching the state from the current project
+        """
+        writer = self.getWriterFactoryFromProject()()
+        writer.params = self.readParamsFromProject()
+        writer.params["Appearance"][
+            "Base layer"] = self.getBasemapsFromProject()
+        return writer
+
+    def saveWriterToProject(self, writer):
+        """
+        Saves the settings from a writer to the current project
+        """
+        QgsProject.instance().removeEntry("qgis2web", "/")
+
+        self.saveTypeToProject(writer.type())
+        self.saveParamsToProject(writer.params)
+
+        basemaps = writer.params["Appearance"]["Base layer"]
+        WRITER_REGISTRY.saveBasemapsToProject(basemaps)
+
 
 # canonical instance.
 WRITER_REGISTRY = WriterRegistry()

--- a/writerRegistry.py
+++ b/writerRegistry.py
@@ -22,6 +22,7 @@ from PyQt4.QtCore import (QObject)
 from olwriter import (OpenLayersWriter)
 from leafletWriter import (LeafletWriter)
 from configparams import (getDefaultParams)
+
 translator = QObject()
 
 
@@ -103,9 +104,15 @@ class WriterRegistry(object):
         """
         for group, settings in params.iteritems():
             for param, value in settings.iteritems():
-                QgsProject.instance().writeEntry("qgis2web",
-                                                 self.sanitiseKey(param),
-                                                 value)
+                if isinstance(value, bool):
+                    QgsProject.instance().writeEntryBool("qgis2web",
+                                                         self.sanitiseKey(
+                                                             param),
+                                                         value)
+                else:
+                    QgsProject.instance().writeEntry("qgis2web",
+                                                     self.sanitiseKey(param),
+                                                     value)
 
     def readParamFromProject(self, parameter, default_value):
         """
@@ -124,17 +131,17 @@ class WriterRegistry(object):
         value = default_value
         if isinstance(default_value, bool):
             if project.readBoolEntry(
-                    "qgis2web", key_string)[0] != 0:
+                    "qgis2web", key_string)[1]:
                 value = project.readBoolEntry("qgis2web",
                                               key_string)[0]
         elif isinstance(default_value, int):
             if project.readNumEntry(
-                    "qgis2web", key_string)[0] != 0:
+                    "qgis2web", key_string)[1]:
                 value = project.readNumEntry("qgis2web",
                                              key_string)[0]
         elif isinstance(default_value, tuple):
             if project.readEntry("qgis2web",
-                                 key_string)[0] != 0:
+                                 key_string)[1]:
                 saved_value = project.readEntry(
                     "qgis2web", key_string)[0]
                 if saved_value in default_value:
@@ -147,8 +154,8 @@ class WriterRegistry(object):
             if (isinstance(project.readEntry("qgis2web",
                                              key_string)[0],
                            basestring) and
-                project.readEntry("qgis2web",
-                                  key_string)[0] != ""):
+               project.readEntry("qgis2web",
+               key_string)[0] != ""):
                 value = project.readEntry(
                     "qgis2web", key_string)[0]
 

--- a/writerRegistry.py
+++ b/writerRegistry.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Nyall Dawson (nyall.dawson@gmail.com)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from qgis.core import (QgsProject)
+from PyQt4.QtCore import (QObject)
+
+from olwriter import (OpenLayersWriter)
+from leafletWriter import (LeafletWriter)
+
+translator = QObject()
+
+
+class WriterRegistry(object):
+    """
+    A registry for known writer types.
+    """
+
+    def __init__(self):
+        self.writers = {e.type(): e for e in
+                        [OpenLayersWriter, LeafletWriter]}
+
+    def getWriters(self):
+        """
+        :return: List of available writers
+        """
+        return self.writers.values()
+
+    def saveTypeToProject(self, type):
+        """
+        Stores a writer type as the type associated with the loaded project
+        :param type: type string for associated writer class
+        """
+        assert QgsProject.instance().writeEntry("qgis2web", "mapFormat", type)
+
+    def getWriterFactoryFromProject(self):
+        """
+        Returns the factory for the writer type associated with the
+        load project.
+        :return:
+        """
+        try:
+            type = QgsProject.instance().readEntry("qgis2web",
+                                                   "mapFormat")[0]
+            for w in self.writers.values():
+                if type.lower() == w.type().lower():
+                    return w
+
+        except:
+            pass
+
+        return OpenLayersWriter  # default to OpenLayersWriter
+
+
+# canonical instance.
+WRITER_REGISTRY = WriterRegistry()

--- a/writerRegistry.py
+++ b/writerRegistry.py
@@ -26,6 +26,7 @@ translator = QObject()
 
 
 class WriterRegistry(object):
+
     """
     A registry for known writer types.
     """
@@ -65,6 +66,28 @@ class WriterRegistry(object):
 
         return OpenLayersWriter  # default to OpenLayersWriter
 
+    def saveBasemapsToProject(self, basemaps):
+        """
+        Stores a list of enabled basemaps for the writer
+        in the current project.
+        :param basemaps: list of basemap names
+        """
+        basemaplist = ",".join(basemaps)
+        QgsProject.instance().writeEntry("qgis2web", "Basemaps", basemaplist)
+
+    def getBasemapsFromProject(self):
+        """
+        Returns a list of enabled basemaps for the writer stored
+        in the current project.
+        """
+        try:
+            basemaps = QgsProject.instance().readEntry(
+                "qgis2web", "Basemaps")[0]
+            if basemaps.strip() == '':
+                return []
+            return basemaps.split(",")
+        except:
+            return []
 
 # canonical instance.
 WRITER_REGISTRY = WriterRegistry()


### PR DESCRIPTION
Moves responsibility for saving writer settings from main dialog out to a new writer registry. This allows:

- more fine-tuned unit testing
- creation of writers matching the project state without requiring a dialog (eg future processing alg)
- future possibility of saving/restoring parameter sets to a non-project format (eg a preset settings file)

This also fixes some existing issues where certain settings are not correctly saved/restored to projects