### PR TITLE
Popup bug fix

### DIFF
--- a/resources/qgis2web.js
+++ b/resources/qgis2web.js
@@ -94,7 +94,6 @@ var onPointerMove = function(evt) {
             return;
         }
 
-
         var doPopup = false;
         if ( count == 1) {
             currentFeature = feature;

--- a/resources/qgis2web.js
+++ b/resources/qgis2web.js
@@ -85,6 +85,7 @@ var onPointerMove = function(evt) {
     var currentFeature;
     var currentLayer;
     var currentFeatureKeys;
+    var count = 1;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         // We only care about features from layers in the layersList, ignore
         // any other layers which the map might contain such as the vector
@@ -92,38 +93,43 @@ var onPointerMove = function(evt) {
         if (layersList.indexOf(layer) === -1) {
             return;
         }
-        currentFeature = feature;
-        currentLayer = layer;
-        currentFeatureKeys = currentFeature.getKeys();
+
+
         var doPopup = false;
-        for (k in layer.get('fieldImages')) {
-            if (layer.get('fieldImages')[k] != "Hidden") {
-                doPopup = true;
-            }
-        }
-        if (doPopup) {
-            popupText = '<table>';
-            for (var i=0; i<currentFeatureKeys.length; i++) {
-                if (currentFeatureKeys[i] != 'geometry') {
-                    popupField = '';
-                    if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                        popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                    } else {
-                        popupField += '<td colspan="2">';
-                    }
-                    if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                        popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                    }
-                    if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                        popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                    } else {
-                        popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                    }
-                    popupText = popupText + '<tr>' + popupField + '</tr>';
+        if ( count == 1) {
+            currentFeature = feature;
+            currentLayer = layer;
+            currentFeatureKeys = currentFeature.getKeys();
+            for (k in layer.get('fieldImages')) {
+                if (layer.get('fieldImages')[k] != "Hidden") {
+                    doPopup = true;
                 }
             }
-            popupText = popupText + '</table>';
+            if (doPopup) {
+                popupText = '<table>';
+                for (var i=0; i<currentFeatureKeys.length; i++) {
+                    if (currentFeatureKeys[i] != 'geometry') {
+                        popupField = '';
+                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                        } else {
+                            popupField += '<td colspan="2">';
+                        }
+                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                        }
+                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                        } else {
+                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                        }
+                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                    }
+                }
+                popupText = popupText + '</table>';
+            }
         }
+        count++;
     });
 
     if (doHighlight) {
@@ -193,38 +199,42 @@ var onSingleClick = function(evt) {
     var popupText = '';
     var currentFeature;
     var currentFeatureKeys;
+    var count = 1;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
-        currentFeature = feature;
-        currentFeatureKeys = currentFeature.getKeys();
         var doPopup = false;
-        for (k in layer.get('fieldImages')) {
-            if (layer.get('fieldImages')[k] != "Hidden") {
-                doPopup = true;
-            }
-        }
-        if (doPopup) {
-            popupText = '<table>';
-            for (var i=0; i<currentFeatureKeys.length; i++) {
-                if (currentFeatureKeys[i] != 'geometry') {
-                    popupField = '';
-                    if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                        popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                    } else {
-                        popupField += '<td colspan="2">';
-                    }
-                    if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                        popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                    }
-                    if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                        popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                    } else {
-                        popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                    }
-                    popupText = popupText + '<tr>' + popupField + '</tr>';
+        if (count == 1) {
+            currentFeature = feature;
+            currentFeatureKeys = currentFeature.getKeys();
+            for (k in layer.get('fieldImages')) {
+                if (layer.get('fieldImages')[k] != "Hidden") {
+                    doPopup = true;
                 }
             }
-            popupText = popupText + '</table>';
+            if (doPopup) {
+                popupText = '<table>';
+                for (var i=0; i<currentFeatureKeys.length; i++) {
+                    if (currentFeatureKeys[i] != 'geometry') {
+                        popupField = '';
+                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                        } else {
+                            popupField += '<td colspan="2">';
+                        }
+                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                        }
+                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                        } else {
+                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                        }
+                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                    }
+                }
+                popupText = popupText + '</table>';
+            }
         }
+        count++;
     });
 
     if (popupText) {


### PR DESCRIPTION
This is a bug fix for qgis2web.js file. The issue was that the `map.forEachFeatureAtPixel` loop read the features from top-most to bottom-most. Since the bottom-most feature is read last, it overwrites the `popupText` table with its information. What we want is the information to be displayed for the top-most layer (not the bottom-most). This fix stops the overwriting by adding a counter, forcing the `popupText` to populate with information from the first encountered feature. There was a similar bug with highlighting option (the bottom-most feature would get highlighted). This counter seemed to fix both bugs. This fix was tested on a multi-layered maps and seemed to work well.

Few things I noticed, but did not fix :
Categorized features do not get highlighted (highlighter "freezes/stops working" after encountering a categorized icon).
When doHighlight = true; doHover = false; (get popup by clicking does not work; the feature is highlighted, but when clicking on it nothing happens).

My first Git experience, hope everything uploaded correctly (it was a bit confusing!)