### PR TITLE
Fixed popups for clustered points (please don't merge until tests are fixed)

### DIFF
--- a/olStyleScripts.py
+++ b/olStyleScripts.py
@@ -211,7 +211,7 @@ def exportStyles(layers, folder, clustered):
     };
     %(value)s
     %(style)s;
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -234,9 +234,9 @@ def exportStyles(layers, folder, clustered):
         }
     } else {
         if (%(label)s !== null%(labelRes)s) {
-            var labelText = String(%(label)s);
+            labelText = String(%(label)s);
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!%(cache)s[key]){

--- a/olStyleScripts.py
+++ b/olStyleScripts.py
@@ -212,25 +212,47 @@ def exportStyles(layers, folder, clustered):
     %(value)s
     %(style)s;
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!%(cache)s[key]){
+            var text = new ol.style.Text({
+                  font: '%(size)spx \\'%(face)s\\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: '%(color)s'
+                  }),%(stroke)s
+                });
+            %(cache)s[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!%(cache)s[key]){
-        var text = new ol.style.Text({
-              font: '%(size)spx \\'%(face)s\\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: '%(color)s'
-              }),%(stroke)s
-            });
-        %(cache)s[key] = new ol.style.Style({"text": text})
+        if (%(label)s !== null%(labelRes)s) {
+            var labelText = String(%(label)s);
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!%(cache)s[key]){
+            var text = new ol.style.Text({
+                    font: '%(size)spx \\'%(face)s\\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: '%(color)s'
+                    }),%(stroke)s
+                });
+            %(cache)s[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [%(cache)s[key]];
     allStyles.push.apply(allStyles, style);

--- a/olStyleScripts.py
+++ b/olStyleScripts.py
@@ -212,9 +212,9 @@ def exportStyles(layers, folder, clustered):
     %(value)s
     %(style)s;
     if (size >= 2) {
-        labelText = size.toString();
+        labelText = size.toString()
     } else {
-        labelText = "";
+        labelText = ""
     }
     var key = value + "_" + labelText
 

--- a/olStyleScripts.py
+++ b/olStyleScripts.py
@@ -178,7 +178,7 @@ def exportStyles(layers, folder, clustered):
             r = layer.customProperty("labeling/textColorR")
             g = layer.customProperty("labeling/textColorG")
             b = layer.customProperty("labeling/textColorB")
-            color = "rgba(%s, %s, %s, 255)" % (r, g, b)
+            color = "rgba(%s, %s, %s, 1)" % (r, g, b)
             face = layer.customProperty("labeling/fontFamily")
             palyr = QgsPalLayerSettings()
             palyr.readFromLayer(layer)
@@ -211,10 +211,10 @@ def exportStyles(layers, folder, clustered):
     };
     %(value)s
     %(style)s;
-    if (%(label)s !== null%(labelRes)s) {
-        var labelText = String(%(label)s);
+    if (size >= 2) {
+        labelText = size.toString();
     } else {
-        var labelText = ""
+        labelText = "";
     }
     var key = value + "_" + labelText
 
@@ -222,10 +222,9 @@ def exportStyles(layers, folder, clustered):
         var text = new ol.style.Text({
               font: '%(size)spx \\'%(face)s\\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
                 color: '%(color)s'
               }),%(stroke)s

--- a/olStyleScripts.py
+++ b/olStyleScripts.py
@@ -211,6 +211,7 @@ def exportStyles(layers, folder, clustered):
     };
     %(value)s
     %(style)s;
+    var labelText = ""
     if (size >= 2) {
         labelText = size.toString()
     } else {

--- a/resources/qgis2web.css
+++ b/resources/qgis2web.css
@@ -30,7 +30,9 @@ th, td {
     left: -50px;   
     height: auto;
     width: auto;
-    min-width: 100px;     
+    min-width: 100px;
+    max-height:400px;  
+    overflow: auto;      
 }
 
 .ol-popup-closer {
@@ -49,4 +51,17 @@ th, td {
     color: #666;
     font-family: sans-serif;
     font-size: 100%;
+}
+
+#popup-content>ul>li:nth-child(even) {
+    background-color: #eee;
+}
+
+#popup-content ul {
+    list-style-type: none;
+    padding-left: 0;
+}
+
+#popup-content li {
+    margin-bottom:0.25em;
 }

--- a/resources/qgis2web.js
+++ b/resources/qgis2web.js
@@ -131,7 +131,7 @@ var onPointerMove = function(evt) {
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
                         } 
-                        popupText = popupText + '</table></li>'    
+                        popupText = popupText + '</table></li>';    
                     }
                     popupText = popupText + '</ul>';
                 }
@@ -251,27 +251,27 @@ var onSingleClick = function(evt) {
                     for(var n=0; n<clusteredFeatures.length; n++) {
                         clusterFeature = clusteredFeatures[n];
                         currentFeatureKeys = clusterFeature.getKeys();
-                        popupText = popupText + '<li>'
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong>&nbsp;';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
-                                    popupField += '';
+                                    popupField += '<td colspan="2">';
                                 }
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
                                     popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
                                 }
                                 if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '<br />' : '');
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
                                 } else {
-                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /><br />' : '');
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
                                 }
-                                popupText = popupText + popupField;
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
                         } 
-                        popupText = popupText + '</li>'    
+                        popupText = popupText + '</table></li>';    
                     }
                     popupText = popupText + '</ul>';
                 }

--- a/resources/qgis2web.js
+++ b/resources/qgis2web.js
@@ -102,21 +102,21 @@ var onPointerMove = function(evt) {
                 }
             }
             currentFeature = feature;
+            currentLayer = layer;
             clusteredFeatures = feature.get("features");
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -130,9 +130,10 @@ var onPointerMove = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>'    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();
@@ -246,33 +247,33 @@ var onSingleClick = function(evt) {
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong>&nbsp;';
                                 } else {
-                                    popupField += '<td colspan="2">';
+                                    popupField += '';
                                 }
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
                                     popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
                                 }
                                 if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '<br />' : '');
                                 } else {
-                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /><br />' : '');
                                 }
-                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                                popupText = popupText + popupField;
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</li>'    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();

--- a/resources/qgis2web.js
+++ b/resources/qgis2web.js
@@ -86,6 +86,7 @@ var onPointerMove = function(evt) {
     var currentLayer;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         // We only care about features from layers in the layersList, ignore
         // any other layers which the map might contain such as the vector
@@ -95,36 +96,69 @@ var onPointerMove = function(evt) {
         }
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentLayer = layer;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;
@@ -198,38 +232,73 @@ var onSingleClick = function(evt) {
     var currentFeature;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;

--- a/test/data/control/ol3_address.js
+++ b/test/data/control/ol3_address.js
@@ -86,7 +86,6 @@ var onPointerMove = function(evt) {
     var currentLayer;
     var currentFeatureKeys;
     var count = 1;
-    var count = 1;
     var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         // We only care about features from layers in the layersList, ignore

--- a/test/data/control/ol3_address.js
+++ b/test/data/control/ol3_address.js
@@ -86,6 +86,8 @@ var onPointerMove = function(evt) {
     var currentLayer;
     var currentFeatureKeys;
     var count = 1;
+    var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         // We only care about features from layers in the layersList, ignore
         // any other layers which the map might contain such as the vector
@@ -95,36 +97,69 @@ var onPointerMove = function(evt) {
         }
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentLayer = layer;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;
@@ -198,38 +233,73 @@ var onSingleClick = function(evt) {
     var currentFeature;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;

--- a/test/data/control/ol3_address.js
+++ b/test/data/control/ol3_address.js
@@ -102,21 +102,21 @@ var onPointerMove = function(evt) {
                 }
             }
             currentFeature = feature;
+            currentLayer = layer;
             clusteredFeatures = feature.get("features");
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -130,9 +130,10 @@ var onPointerMove = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();
@@ -246,17 +247,16 @@ var onSingleClick = function(evt) {
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -270,9 +270,10 @@ var onSingleClick = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();

--- a/test/data/control/ol3_geolocate.js
+++ b/test/data/control/ol3_geolocate.js
@@ -112,6 +112,7 @@ var onPointerMove = function(evt) {
     var currentLayer;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         // We only care about features from layers in the layersList, ignore
         // any other layers which the map might contain such as the vector
@@ -121,36 +122,69 @@ var onPointerMove = function(evt) {
         }
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentLayer = layer;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;
@@ -224,38 +258,73 @@ var onSingleClick = function(evt) {
     var currentFeature;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;

--- a/test/data/control/ol3_geolocate.js
+++ b/test/data/control/ol3_geolocate.js
@@ -128,21 +128,21 @@ var onPointerMove = function(evt) {
                 }
             }
             currentFeature = feature;
+            currentLayer = layer;
             clusteredFeatures = feature.get("features");
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -156,9 +156,10 @@ var onPointerMove = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();
@@ -272,17 +273,16 @@ var onSingleClick = function(evt) {
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -296,9 +296,10 @@ var onSingleClick = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();

--- a/test/data/control/ol3_highlight.js
+++ b/test/data/control/ol3_highlight.js
@@ -86,6 +86,7 @@ var onPointerMove = function(evt) {
     var currentLayer;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         // We only care about features from layers in the layersList, ignore
         // any other layers which the map might contain such as the vector
@@ -95,36 +96,69 @@ var onPointerMove = function(evt) {
         }
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentLayer = layer;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;
@@ -198,38 +232,73 @@ var onSingleClick = function(evt) {
     var currentFeature;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;

--- a/test/data/control/ol3_highlight.js
+++ b/test/data/control/ol3_highlight.js
@@ -102,21 +102,21 @@ var onPointerMove = function(evt) {
                 }
             }
             currentFeature = feature;
+            currentLayer = layer;
             clusteredFeatures = feature.get("features");
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -130,9 +130,10 @@ var onPointerMove = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();
@@ -246,17 +247,16 @@ var onSingleClick = function(evt) {
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -270,9 +270,10 @@ var onSingleClick = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();

--- a/test/data/control/ol3_json_line_categorized.html
+++ b/test/data/control/ol3_json_line_categorized.html
@@ -90,7 +90,7 @@ var style_pipelines0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           labelText = String("");
+            labelText = String("");
         } else {
             labelText = ""
         }

--- a/test/data/control/ol3_json_line_categorized.html
+++ b/test/data/control/ol3_json_line_categorized.html
@@ -75,9 +75,9 @@ var style_pipelines0 = function(feature, resolution){
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_FieldSites0[key]){
+    if (!styleCache_pipelines0[key]){
         var text = new ol.style.Text({
-              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
+              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
               textAlign: "center",
               offsetX: 0,

--- a/test/data/control/ol3_json_line_categorized.html
+++ b/test/data/control/ol3_json_line_categorized.html
@@ -89,8 +89,8 @@ var style_pipelines0 = function(feature, resolution){
             styleCache_pipelines0[key] = new ol.style.Style({"text": text})
         }
     } else {
-        if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+        if ("" !== null) {
++           var labelText = String("");
         } else {
             var labelText = ""
         }

--- a/test/data/control/ol3_json_line_categorized.html
+++ b/test/data/control/ol3_json_line_categorized.html
@@ -67,7 +67,7 @@ var style_pipelines0 = function(feature, resolution){
     };
     var value = feature.get("LOCDESC");
     var style = categories_pipelines0(feature, value);
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -90,9 +90,9 @@ var style_pipelines0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           var labelText = String("");
++           labelText = String("");
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_pipelines0[key]){

--- a/test/data/control/ol3_json_line_categorized.html
+++ b/test/data/control/ol3_json_line_categorized.html
@@ -68,25 +68,47 @@ var style_pipelines0 = function(feature, resolution){
     var value = feature.get("LOCDESC");
     var style = categories_pipelines0(feature, value);
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_pipelines0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_pipelines0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_pipelines0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_pipelines0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_pipelines0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_line_categorized.html
+++ b/test/data/control/ol3_json_line_categorized.html
@@ -67,23 +67,23 @@ var style_pipelines0 = function(feature, resolution){
     };
     var value = feature.get("LOCDESC");
     var style = categories_pipelines0(feature, value);
-    if ("" !== null) {
-        var labelText = String("");
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_pipelines0[key]){
+    if (!styleCache_FieldSites0[key]){
         var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_pipelines0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_json_line_graduated.html
+++ b/test/data/control/ol3_json_line_graduated.html
@@ -73,25 +73,47 @@ var style_pipelines0 = function(feature, resolution){
         }
     };
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_pipelines0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_pipelines0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_pipelines0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_pipelines0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_pipelines0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_line_graduated.html
+++ b/test/data/control/ol3_json_line_graduated.html
@@ -72,23 +72,23 @@ var style_pipelines0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    if ("" !== null) {
-        var labelText = String("");
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_pipelines0[key]){
+    if (!styleCache_FieldSites0[key]){
         var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_pipelines0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_json_line_graduated.html
+++ b/test/data/control/ol3_json_line_graduated.html
@@ -72,7 +72,7 @@ var style_pipelines0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -95,9 +95,9 @@ var style_pipelines0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           var labelText = String("");
++           labelText = String("");
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_pipelines0[key]){

--- a/test/data/control/ol3_json_line_graduated.html
+++ b/test/data/control/ol3_json_line_graduated.html
@@ -94,8 +94,8 @@ var style_pipelines0 = function(feature, resolution){
             styleCache_pipelines0[key] = new ol.style.Style({"text": text})
         }
     } else {
-        if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+        if ("" !== null) {
++           var labelText = String("");
         } else {
             var labelText = ""
         }

--- a/test/data/control/ol3_json_line_graduated.html
+++ b/test/data/control/ol3_json_line_graduated.html
@@ -80,9 +80,9 @@ var style_pipelines0 = function(feature, resolution){
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_FieldSites0[key]){
+    if (!styleCache_pipelines0[key]){
         var text = new ol.style.Text({
-              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
+              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
               textAlign: "center",
               offsetX: 0,

--- a/test/data/control/ol3_json_line_graduated.html
+++ b/test/data/control/ol3_json_line_graduated.html
@@ -95,7 +95,7 @@ var style_pipelines0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           labelText = String("");
+            labelText = String("");
         } else {
             labelText = ""
         }

--- a/test/data/control/ol3_json_line_single.html
+++ b/test/data/control/ol3_json_line_single.html
@@ -55,23 +55,23 @@ var style_pipelines0 = function(feature, resolution){
     var style = [ new ol.style.Style({
         stroke: new ol.style.Stroke({color: 'rgba(242,66,72,1.0)', lineDash: null, lineCap: 'square', lineJoin: 'bevel', width: 0}),
     })];
-    if ("" !== null) {
-        var labelText = String("");
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_pipelines0[key]){
+    if (!styleCache_FieldSites0[key]){
         var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_pipelines0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_json_line_single.html
+++ b/test/data/control/ol3_json_line_single.html
@@ -63,9 +63,9 @@ var style_pipelines0 = function(feature, resolution){
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_FieldSites0[key]){
+    if (!styleCache_pipelines0[key]){
         var text = new ol.style.Text({
-              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
+              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
               textAlign: "center",
               offsetX: 0,

--- a/test/data/control/ol3_json_line_single.html
+++ b/test/data/control/ol3_json_line_single.html
@@ -78,7 +78,7 @@ var style_pipelines0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           labelText = String("");
+            labelText = String("");
         } else {
             labelText = ""
         }

--- a/test/data/control/ol3_json_line_single.html
+++ b/test/data/control/ol3_json_line_single.html
@@ -56,25 +56,47 @@ var style_pipelines0 = function(feature, resolution){
         stroke: new ol.style.Stroke({color: 'rgba(242,66,72,1.0)', lineDash: null, lineCap: 'square', lineJoin: 'bevel', width: 0}),
     })];
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_pipelines0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_pipelines0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_pipelines0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_pipelines0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_pipelines0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_line_single.html
+++ b/test/data/control/ol3_json_line_single.html
@@ -55,7 +55,7 @@ var style_pipelines0 = function(feature, resolution){
     var style = [ new ol.style.Style({
         stroke: new ol.style.Stroke({color: 'rgba(242,66,72,1.0)', lineDash: null, lineCap: 'square', lineJoin: 'bevel', width: 0}),
     })];
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -78,9 +78,9 @@ var style_pipelines0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           var labelText = String("");
++           labelText = String("");
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_pipelines0[key]){

--- a/test/data/control/ol3_json_line_single.html
+++ b/test/data/control/ol3_json_line_single.html
@@ -77,8 +77,8 @@ var style_pipelines0 = function(feature, resolution){
             styleCache_pipelines0[key] = new ol.style.Style({"text": text})
         }
     } else {
-        if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+        if ("" !== null) {
++           var labelText = String("");
         } else {
             var labelText = ""
         }

--- a/test/data/control/ol3_json_point_categorized.html
+++ b/test/data/control/ol3_json_point_categorized.html
@@ -83,25 +83,47 @@ var style_airports0 = function(feature, resolution){
     var value = feature.get("USE");
     var style = categories_airports0(feature, value);
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_airports0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_airports0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_point_categorized.html
+++ b/test/data/control/ol3_json_point_categorized.html
@@ -90,9 +90,9 @@ var style_airports0 = function(feature, resolution){
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_FieldSites0[key]){
+    if (!styleCache_airports0[key]){
         var text = new ol.style.Text({
-              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
+              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
               textAlign: "center",
               offsetX: 0,

--- a/test/data/control/ol3_json_point_categorized.html
+++ b/test/data/control/ol3_json_point_categorized.html
@@ -104,8 +104,8 @@ var style_airports0 = function(feature, resolution){
             styleCache_airports0[key] = new ol.style.Style({"text": text})
         }
     } else {
-        if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+        if ("" !== null) {
++           var labelText = String("");
         } else {
             var labelText = ""
         }

--- a/test/data/control/ol3_json_point_categorized.html
+++ b/test/data/control/ol3_json_point_categorized.html
@@ -82,23 +82,23 @@ var style_airports0 = function(feature, resolution){
     };
     var value = feature.get("USE");
     var style = categories_airports0(feature, value);
-    if ("" !== null) {
-        var labelText = String("");
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_airports0[key]){
+    if (!styleCache_FieldSites0[key]){
         var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_airports0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_json_point_categorized.html
+++ b/test/data/control/ol3_json_point_categorized.html
@@ -105,7 +105,7 @@ var style_airports0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           labelText = String("");
+            labelText = String("");
         } else {
             labelText = ""
         }

--- a/test/data/control/ol3_json_point_categorized.html
+++ b/test/data/control/ol3_json_point_categorized.html
@@ -82,7 +82,7 @@ var style_airports0 = function(feature, resolution){
     };
     var value = feature.get("USE");
     var style = categories_airports0(feature, value);
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -105,9 +105,9 @@ var style_airports0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           var labelText = String("");
++           labelText = String("");
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_airports0[key]){

--- a/test/data/control/ol3_json_point_graduated.html
+++ b/test/data/control/ol3_json_point_graduated.html
@@ -78,25 +78,47 @@ var style_airports0 = function(feature, resolution){
         }
     };
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_airports0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_airports0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_point_graduated.html
+++ b/test/data/control/ol3_json_point_graduated.html
@@ -77,23 +77,23 @@ var style_airports0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    if ("" !== null) {
-        var labelText = String("");
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_airports0[key]){
+    if (!styleCache_FieldSites0[key]){
         var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_airports0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_json_point_graduated.html
+++ b/test/data/control/ol3_json_point_graduated.html
@@ -99,8 +99,8 @@ var style_airports0 = function(feature, resolution){
             styleCache_airports0[key] = new ol.style.Style({"text": text})
         }
     } else {
-        if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+        if ("" !== null) {
++           var labelText = String("");
         } else {
             var labelText = ""
         }

--- a/test/data/control/ol3_json_point_graduated.html
+++ b/test/data/control/ol3_json_point_graduated.html
@@ -77,7 +77,7 @@ var style_airports0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -100,9 +100,9 @@ var style_airports0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           var labelText = String("");
++           labelText = String("");
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_airports0[key]){

--- a/test/data/control/ol3_json_point_graduated.html
+++ b/test/data/control/ol3_json_point_graduated.html
@@ -100,7 +100,7 @@ var style_airports0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           labelText = String("");
+            labelText = String("");
         } else {
             labelText = ""
         }

--- a/test/data/control/ol3_json_point_graduated.html
+++ b/test/data/control/ol3_json_point_graduated.html
@@ -85,9 +85,9 @@ var style_airports0 = function(feature, resolution){
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_FieldSites0[key]){
+    if (!styleCache_airports0[key]){
         var text = new ol.style.Text({
-              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
+              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
               textAlign: "center",
               offsetX: 0,

--- a/test/data/control/ol3_json_point_single.html
+++ b/test/data/control/ol3_json_point_single.html
@@ -56,7 +56,7 @@ var style_airports0 = function(feature, resolution){
         image: new ol.style.Circle({radius: 4.0 + size,
             stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(39,147,25,1.0)'})})
     })];
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -79,9 +79,9 @@ var style_airports0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           var labelText = String("");
++           labelText = String("");
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_airports0[key]){

--- a/test/data/control/ol3_json_point_single.html
+++ b/test/data/control/ol3_json_point_single.html
@@ -78,8 +78,8 @@ var style_airports0 = function(feature, resolution){
             styleCache_airports0[key] = new ol.style.Style({"text": text})
         }
     } else {
-        if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+        if ("" !== null) {
++           var labelText = String("");
         } else {
             var labelText = ""
         }

--- a/test/data/control/ol3_json_point_single.html
+++ b/test/data/control/ol3_json_point_single.html
@@ -57,25 +57,47 @@ var style_airports0 = function(feature, resolution){
             stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(39,147,25,1.0)'})})
     })];
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_airports0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_airports0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_point_single.html
+++ b/test/data/control/ol3_json_point_single.html
@@ -79,7 +79,7 @@ var style_airports0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           labelText = String("");
+            labelText = String("");
         } else {
             labelText = ""
         }

--- a/test/data/control/ol3_json_point_single.html
+++ b/test/data/control/ol3_json_point_single.html
@@ -56,10 +56,11 @@ var style_airports0 = function(feature, resolution){
         image: new ol.style.Circle({radius: 4.0 + size,
             stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(39,147,25,1.0)'})})
     })];
-    if ("" !== null) {
-        var labelText = String("");
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
@@ -67,12 +68,11 @@ var style_airports0 = function(feature, resolution){
         var text = new ol.style.Text({
               font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_airports0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_json_polygon_categorized.html
+++ b/test/data/control/ol3_json_polygon_categorized.html
@@ -132,23 +132,23 @@ var style_lakes0 = function(feature, resolution){
     };
     var value = feature.get("NAMES");
     var style = categories_lakes0(feature, value);
-    if ("" !== null) {
-        var labelText = String("");
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_lakes0[key]){
+    if (!styleCache_FieldSites0[key]){
         var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_lakes0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_json_polygon_categorized.html
+++ b/test/data/control/ol3_json_polygon_categorized.html
@@ -133,25 +133,47 @@ var style_lakes0 = function(feature, resolution){
     var value = feature.get("NAMES");
     var style = categories_lakes0(feature, value);
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_lakes0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_lakes0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_lakes0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_lakes0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_lakes0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_lakes0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_lakes0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_polygon_categorized.html
+++ b/test/data/control/ol3_json_polygon_categorized.html
@@ -132,7 +132,7 @@ var style_lakes0 = function(feature, resolution){
     };
     var value = feature.get("NAMES");
     var style = categories_lakes0(feature, value);
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -155,9 +155,9 @@ var style_lakes0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           var labelText = String("");
++           labelText = String("");
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_lakes0[key]){

--- a/test/data/control/ol3_json_polygon_categorized.html
+++ b/test/data/control/ol3_json_polygon_categorized.html
@@ -155,7 +155,7 @@ var style_lakes0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           labelText = String("");
+            labelText = String("");
         } else {
             labelText = ""
         }

--- a/test/data/control/ol3_json_polygon_categorized.html
+++ b/test/data/control/ol3_json_polygon_categorized.html
@@ -154,8 +154,8 @@ var style_lakes0 = function(feature, resolution){
             styleCache_lakes0[key] = new ol.style.Style({"text": text})
         }
     } else {
-        if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+        if ("" !== null) {
++           var labelText = String("");
         } else {
             var labelText = ""
         }

--- a/test/data/control/ol3_json_polygon_categorized.html
+++ b/test/data/control/ol3_json_polygon_categorized.html
@@ -140,9 +140,9 @@ var style_lakes0 = function(feature, resolution){
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_FieldSites0[key]){
+    if (!styleCache_lakes0[key]){
         var text = new ol.style.Text({
-              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
+              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
               textAlign: "center",
               offsetX: 0,

--- a/test/data/control/ol3_json_polygon_graduated.html
+++ b/test/data/control/ol3_json_polygon_graduated.html
@@ -72,23 +72,23 @@ var style_lakes0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    if ("" !== null) {
-        var labelText = String("");
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_lakes0[key]){
+    if (!styleCache_FieldSites0[key]){
         var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_lakes0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_json_polygon_graduated.html
+++ b/test/data/control/ol3_json_polygon_graduated.html
@@ -73,25 +73,47 @@ var style_lakes0 = function(feature, resolution){
         }
     };
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_lakes0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_lakes0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_lakes0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_lakes0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_lakes0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_lakes0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_lakes0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_polygon_graduated.html
+++ b/test/data/control/ol3_json_polygon_graduated.html
@@ -80,9 +80,9 @@ var style_lakes0 = function(feature, resolution){
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_FieldSites0[key]){
+    if (!styleCache_lakes0[key]){
         var text = new ol.style.Text({
-              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
+              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
               textAlign: "center",
               offsetX: 0,

--- a/test/data/control/ol3_json_polygon_graduated.html
+++ b/test/data/control/ol3_json_polygon_graduated.html
@@ -94,8 +94,8 @@ var style_lakes0 = function(feature, resolution){
             styleCache_lakes0[key] = new ol.style.Style({"text": text})
         }
     } else {
-        if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+        if ("" !== null) {
++           var labelText = String("");
         } else {
             var labelText = ""
         }

--- a/test/data/control/ol3_json_polygon_graduated.html
+++ b/test/data/control/ol3_json_polygon_graduated.html
@@ -95,7 +95,7 @@ var style_lakes0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           labelText = String("");
+            labelText = String("");
         } else {
             labelText = ""
         }

--- a/test/data/control/ol3_json_polygon_graduated.html
+++ b/test/data/control/ol3_json_polygon_graduated.html
@@ -72,7 +72,7 @@ var style_lakes0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -95,9 +95,9 @@ var style_lakes0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           var labelText = String("");
++           labelText = String("");
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_lakes0[key]){

--- a/test/data/control/ol3_json_polygon_single.html
+++ b/test/data/control/ol3_json_polygon_single.html
@@ -56,25 +56,47 @@ var style_lakes0 = function(feature, resolution){
         stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(56,204,206,1.0)'})
     })];
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_lakes0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_lakes0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_lakes0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_lakes0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_lakes0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_lakes0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_lakes0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_polygon_single.html
+++ b/test/data/control/ol3_json_polygon_single.html
@@ -78,7 +78,7 @@ var style_lakes0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           labelText = String("");
+            labelText = String("");
         } else {
             labelText = ""
         }

--- a/test/data/control/ol3_json_polygon_single.html
+++ b/test/data/control/ol3_json_polygon_single.html
@@ -55,7 +55,7 @@ var style_lakes0 = function(feature, resolution){
     var style = [ new ol.style.Style({
         stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(56,204,206,1.0)'})
     })];
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -78,9 +78,9 @@ var style_lakes0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           var labelText = String("");
++           labelText = String("");
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_lakes0[key]){

--- a/test/data/control/ol3_json_polygon_single.html
+++ b/test/data/control/ol3_json_polygon_single.html
@@ -55,23 +55,23 @@ var style_lakes0 = function(feature, resolution){
     var style = [ new ol.style.Style({
         stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(56,204,206,1.0)'})
     })];
-    if ("" !== null) {
-        var labelText = String("");
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_lakes0[key]){
+    if (!styleCache_FieldSites0[key]){
         var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_lakes0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_json_polygon_single.html
+++ b/test/data/control/ol3_json_polygon_single.html
@@ -63,9 +63,9 @@ var style_lakes0 = function(feature, resolution){
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_FieldSites0[key]){
+    if (!styleCache_lakes0[key]){
         var text = new ol.style.Text({
-              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
+              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
               textAlign: "center",
               offsetX: 0,

--- a/test/data/control/ol3_json_polygon_single.html
+++ b/test/data/control/ol3_json_polygon_single.html
@@ -77,8 +77,8 @@ var style_lakes0 = function(feature, resolution){
             styleCache_lakes0[key] = new ol.style.Style({"text": text})
         }
     } else {
-        if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+        if ("" !== null) {
++           var labelText = String("");
         } else {
             var labelText = ""
         }

--- a/test/data/control/ol3_labels.js
+++ b/test/data/control/ol3_labels.js
@@ -12,23 +12,23 @@ var style_airports0 = function(feature, resolution){
         image: new ol.style.Circle({radius: 4.0 + size,
             stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(39,147,25,1.0)'})})
     })];
-    if (feature.get("NAME") !== null) {
-        var labelText = String(feature.get("NAME"));
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_airports0[key]){
+    if (!styleCache_FieldSites0[key]){
         var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_airports0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_labels.js
+++ b/test/data/control/ol3_labels.js
@@ -20,9 +20,9 @@ var style_airports0 = function(feature, resolution){
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_FieldSites0[key]){
+    if (!styleCache_airports0[key]){
         var text = new ol.style.Text({
-              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
+              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
               textAlign: "center",
               offsetX: 0,

--- a/test/data/control/ol3_labels.js
+++ b/test/data/control/ol3_labels.js
@@ -12,7 +12,7 @@ var style_airports0 = function(feature, resolution){
         image: new ol.style.Circle({radius: 4.0 + size,
             stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(39,147,25,1.0)'})})
     })];
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -35,9 +35,9 @@ var style_airports0 = function(feature, resolution){
         }
     } else {
         if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+            labelText = String(feature.get("NAME"));
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_airports0[key]){

--- a/test/data/control/ol3_labels.js
+++ b/test/data/control/ol3_labels.js
@@ -13,25 +13,47 @@ var style_airports0 = function(feature, resolution){
             stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(39,147,25,1.0)'})})
     })];
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_airports0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_airports0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_maxzoom.js
+++ b/test/data/control/ol3_maxzoom.js
@@ -86,6 +86,7 @@ var onPointerMove = function(evt) {
     var currentLayer;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         // We only care about features from layers in the layersList, ignore
         // any other layers which the map might contain such as the vector
@@ -95,36 +96,69 @@ var onPointerMove = function(evt) {
         }
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentLayer = layer;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;
@@ -198,38 +232,73 @@ var onSingleClick = function(evt) {
     var currentFeature;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;

--- a/test/data/control/ol3_maxzoom.js
+++ b/test/data/control/ol3_maxzoom.js
@@ -102,21 +102,21 @@ var onPointerMove = function(evt) {
                 }
             }
             currentFeature = feature;
+            currentLayer = layer;
             clusteredFeatures = feature.get("features");
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -130,9 +130,10 @@ var onPointerMove = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();
@@ -246,17 +247,16 @@ var onSingleClick = function(evt) {
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -270,9 +270,10 @@ var onSingleClick = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();

--- a/test/data/control/ol3_measure.js
+++ b/test/data/control/ol3_measure.js
@@ -139,21 +139,21 @@ var onPointerMove = function(evt) {
                 }
             }
             currentFeature = feature;
+            currentLayer = layer;
             clusteredFeatures = feature.get("features");
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -167,9 +167,10 @@ var onPointerMove = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();
@@ -283,17 +284,16 @@ var onSingleClick = function(evt) {
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -307,9 +307,10 @@ var onSingleClick = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();

--- a/test/data/control/ol3_measure.js
+++ b/test/data/control/ol3_measure.js
@@ -123,6 +123,7 @@ var onPointerMove = function(evt) {
     var currentLayer;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         // We only care about features from layers in the layersList, ignore
         // any other layers which the map might contain such as the vector
@@ -132,36 +133,69 @@ var onPointerMove = function(evt) {
         }
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentLayer = layer;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;
@@ -235,38 +269,73 @@ var onSingleClick = function(evt) {
     var currentFeature;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;

--- a/test/data/control/ol3_minzoom.js
+++ b/test/data/control/ol3_minzoom.js
@@ -86,6 +86,7 @@ var onPointerMove = function(evt) {
     var currentLayer;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         // We only care about features from layers in the layersList, ignore
         // any other layers which the map might contain such as the vector
@@ -95,36 +96,69 @@ var onPointerMove = function(evt) {
         }
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentLayer = layer;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;
@@ -198,38 +232,73 @@ var onSingleClick = function(evt) {
     var currentFeature;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;

--- a/test/data/control/ol3_minzoom.js
+++ b/test/data/control/ol3_minzoom.js
@@ -102,21 +102,21 @@ var onPointerMove = function(evt) {
                 }
             }
             currentFeature = feature;
+            currentLayer = layer;
             clusteredFeatures = feature.get("features");
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -130,9 +130,10 @@ var onPointerMove = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();
@@ -246,17 +247,16 @@ var onSingleClick = function(evt) {
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -270,9 +270,10 @@ var onSingleClick = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();

--- a/test/data/control/ol3_rule-based.js
+++ b/test/data/control/ol3_rule-based.js
@@ -52,7 +52,7 @@ var style_airports0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           labelText = String("");
+            labelText = String("");
         } else {
             labelText = ""
         }

--- a/test/data/control/ol3_rule-based.js
+++ b/test/data/control/ol3_rule-based.js
@@ -30,25 +30,47 @@ var style_airports0 = function(feature, resolution){
         var style = rules_airports0(feature, value);
         ;
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_airports0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_airports0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_rule-based.js
+++ b/test/data/control/ol3_rule-based.js
@@ -37,9 +37,9 @@ var style_airports0 = function(feature, resolution){
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_FieldSites0[key]){
+    if (!styleCache_airports0[key]){
         var text = new ol.style.Text({
-              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
+              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
               textAlign: "center",
               offsetX: 0,

--- a/test/data/control/ol3_rule-based.js
+++ b/test/data/control/ol3_rule-based.js
@@ -29,7 +29,7 @@ var style_airports0 = function(feature, resolution){
         }
         var style = rules_airports0(feature, value);
         ;
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -52,9 +52,9 @@ var style_airports0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           var labelText = String("");
++           labelText = String("");
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_airports0[key]){

--- a/test/data/control/ol3_rule-based.js
+++ b/test/data/control/ol3_rule-based.js
@@ -29,23 +29,23 @@ var style_airports0 = function(feature, resolution){
         }
         var style = rules_airports0(feature, value);
         ;
-    if ("" !== null) {
-        var labelText = String("");
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_airports0[key]){
+    if (!styleCache_FieldSites0[key]){
         var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_airports0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_rule-based.js
+++ b/test/data/control/ol3_rule-based.js
@@ -51,8 +51,8 @@ var style_airports0 = function(feature, resolution){
             styleCache_airports0[key] = new ol.style.Style({"text": text})
         }
     } else {
-        if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+        if ("" !== null) {
++           var labelText = String("");
         } else {
             var labelText = ""
         }

--- a/test/data/control/ol3_scalebar.js
+++ b/test/data/control/ol3_scalebar.js
@@ -86,6 +86,7 @@ var onPointerMove = function(evt) {
     var currentLayer;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         // We only care about features from layers in the layersList, ignore
         // any other layers which the map might contain such as the vector
@@ -95,36 +96,69 @@ var onPointerMove = function(evt) {
         }
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentLayer = layer;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;
@@ -198,38 +232,73 @@ var onSingleClick = function(evt) {
     var currentFeature;
     var currentFeatureKeys;
     var count = 1;
+    var clusteredFeatures;
     map.forEachFeatureAtPixel(pixel, function(feature, layer) {
         var doPopup = false;
         if (count == 1) {
-            currentFeature = feature;
-            currentFeatureKeys = currentFeature.getKeys();
             for (k in layer.get('fieldImages')) {
                 if (layer.get('fieldImages')[k] != "Hidden") {
                     doPopup = true;
                 }
             }
-            if (doPopup) {
-                popupText = '<table>';
-                for (var i=0; i<currentFeatureKeys.length; i++) {
-                    if (currentFeatureKeys[i] != 'geometry') {
-                        popupField = '';
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                            popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
-                        } else {
-                            popupField += '<td colspan="2">';
+            currentFeature = feature;
+            clusteredFeatures = feature.get("features");
+            var clusterFeature;
+            if (typeof clusteredFeatures !== "undefined") {
+                if (doPopup) {
+                    popupText = '<table>';
+                }
+                for (var n=0; n<clusteredFeatures.length; n++) {
+                    clusterFeature = clusteredFeatures[n];
+                    currentFeatureKeys = clusterFeature.getKeys();
+                    if (doPopup) {  
+                        for (var i=0; i<currentFeatureKeys.length; i++) {
+                            if (currentFeatureKeys[i] != 'geometry') {
+                                popupField = '';
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                } else {
+                                    popupField += '<td colspan="2">';
+                                }
+                                if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                    popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                                }
+                                if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(clusterFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                                } else {
+                                    popupField += (clusterFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + clusterFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                                }
+                                popupText = popupText + '<tr>' + popupField + '</tr>';
+                            }
                         }
-                        if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
-                            popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
-                        }
-                        if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
-                        } else {
-                            popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
-                        }
-                        popupText = popupText + '<tr>' + popupField + '</tr>';
+                        popupText = popupText + '</table>';
                     }
                 }
-                popupText = popupText + '</table>';
+            } else {
+                currentFeatureKeys = currentFeature.getKeys();
+                if (doPopup) {
+                    popupText = '<table>';
+                    for (var i=0; i<currentFeatureKeys.length; i++) {
+                        if (currentFeatureKeys[i] != 'geometry') {
+                            popupField = '';
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                            } else {
+                                popupField += '<td colspan="2">';
+                            }
+                            if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "header label") {
+                                popupField += '<strong>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</strong><br />';
+                            }
+                            if (layer.get('fieldImages')[currentFeatureKeys[i]] != "Photo") {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? Autolinker.link(String(currentFeature.get(currentFeatureKeys[i]))) + '</td>' : '');
+                            } else {
+                                popupField += (currentFeature.get(currentFeatureKeys[i]) != null ? '<img src="images/' + currentFeature.get(currentFeatureKeys[i]).replace(/[\\\/:]/g, '_').trim()  + '" /></td>' : '');
+                            }
+                            popupText = popupText + '<tr>' + popupField + '</tr>';
+                        }
+                    }
+                    popupText = popupText + '</table>';
+                }
             }
         }
         count++;

--- a/test/data/control/ol3_scalebar.js
+++ b/test/data/control/ol3_scalebar.js
@@ -102,21 +102,21 @@ var onPointerMove = function(evt) {
                 }
             }
             currentFeature = feature;
+            currentLayer = layer;
             clusteredFeatures = feature.get("features");
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -130,9 +130,10 @@ var onPointerMove = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();
@@ -246,17 +247,16 @@ var onSingleClick = function(evt) {
             var clusterFeature;
             if (typeof clusteredFeatures !== "undefined") {
                 if (doPopup) {
-                    popupText = '<table>';
-                }
-                for (var n=0; n<clusteredFeatures.length; n++) {
-                    clusterFeature = clusteredFeatures[n];
-                    currentFeatureKeys = clusterFeature.getKeys();
-                    if (doPopup) {  
+                    popupText = '<ul>';
+                    for(var n=0; n<clusteredFeatures.length; n++) {
+                        clusterFeature = clusteredFeatures[n];
+                        currentFeatureKeys = clusterFeature.getKeys();
+                        popupText = popupText + '<li><table>'
                         for (var i=0; i<currentFeatureKeys.length; i++) {
                             if (currentFeatureKeys[i] != 'geometry') {
                                 popupField = '';
                                 if (layer.get('fieldLabels')[currentFeatureKeys[i]] == "inline label") {
-                                    popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
+                                popupField += '<th>' + layer.get('fieldAliases')[currentFeatureKeys[i]] + ':</th><td>';
                                 } else {
                                     popupField += '<td colspan="2">';
                                 }
@@ -270,9 +270,10 @@ var onSingleClick = function(evt) {
                                 }
                                 popupText = popupText + '<tr>' + popupField + '</tr>';
                             }
-                        }
-                        popupText = popupText + '</table>';
+                        } 
+                        popupText = popupText + '</table></li>';    
                     }
+                    popupText = popupText + '</ul>';
                 }
             } else {
                 currentFeatureKeys = currentFeature.getKeys();

--- a/test/data/control/ol3_svg.js
+++ b/test/data/control/ol3_svg.js
@@ -41,8 +41,8 @@ var style_airports0 = function(feature, resolution){
             styleCache_airports0[key] = new ol.style.Style({"text": text})
         }
     } else {
-        if (feature.get("NAME") !== null) {
-            var labelText = String(feature.get("NAME"));
+        if ("" !== null) {
++           var labelText = String("");
         } else {
             var labelText = ""
         }

--- a/test/data/control/ol3_svg.js
+++ b/test/data/control/ol3_svg.js
@@ -20,25 +20,47 @@ var style_airports0 = function(feature, resolution){
             })
     })];
     var labelText = ""
-    if (size >= 2) {
-        labelText = size.toString()
+    var currentFeature = feature;
+    clusteredFeatures = feature.get("features");
+    if (typeof clusteredFeatures !== "undefined") {
+        if (size >= 2) {
+            labelText = size.toString()
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                  text: labelText,
+                  textAlign: "center",
+                  fill: new ol.style.Fill({
+                    color: 'rgba(0, 0, 0, 1)'
+                  }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     } else {
-        labelText = ""
-    }
-    var key = value + "_" + labelText
-
-    if (!styleCache_airports0[key]){
-        var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-              text: labelText,
-              textAlign: "center",
-              offsetX: 0,
-              offsetY: 0,
-              fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 1)'
-              }),
-            });
-        styleCache_airports0[key] = new ol.style.Style({"text": text})
+        if (feature.get("NAME") !== null) {
+            var labelText = String(feature.get("NAME"));
+        } else {
+            var labelText = ""
+        }
+        var key = value + "_" + labelText
+        if (!styleCache_airports0[key]){
+            var text = new ol.style.Text({
+                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                    text: labelText,
+                    textBaseline: "center",
+                    textAlign: "left",
+                    offsetX: 5,
+                    offsetY: 3,
+                    fill: new ol.style.Fill({
+                      color: 'rgba(0, 0, 0, 1)'
+                    }),
+                });
+            styleCache_airports0[key] = new ol.style.Style({"text": text})
+        }
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_svg.js
+++ b/test/data/control/ol3_svg.js
@@ -27,9 +27,9 @@ var style_airports0 = function(feature, resolution){
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_FieldSites0[key]){
+    if (!styleCache_airports0[key]){
         var text = new ol.style.Text({
-              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
+              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
               textAlign: "center",
               offsetX: 0,

--- a/test/data/control/ol3_svg.js
+++ b/test/data/control/ol3_svg.js
@@ -42,7 +42,7 @@ var style_airports0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           labelText = String("");
+            labelText = String("");
         } else {
             labelText = ""
         }

--- a/test/data/control/ol3_svg.js
+++ b/test/data/control/ol3_svg.js
@@ -19,23 +19,23 @@ var style_airports0 = function(feature, resolution){
                   src: "styles/qgis2web.svg"
             })
     })];
-    if ("" !== null) {
-        var labelText = String("");
+    var labelText = ""
+    if (size >= 2) {
+        labelText = size.toString()
     } else {
-        var labelText = ""
+        labelText = ""
     }
     var key = value + "_" + labelText
 
-    if (!styleCache_airports0[key]){
+    if (!styleCache_FieldSites0[key]){
         var text = new ol.style.Text({
-              font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+              font: '13.0px \'MS Shell Dlg 2\', sans-serif',
               text: labelText,
-              textBaseline: "center",
-              textAlign: "left",
-              offsetX: 5,
-              offsetY: 3,
+              textAlign: "center",
+              offsetX: 0,
+              offsetY: 0,
               fill: new ol.style.Fill({
-                color: 'rgba(0, 0, 0, 255)'
+                color: 'rgba(0, 0, 0, 1)'
               }),
             });
         styleCache_airports0[key] = new ol.style.Style({"text": text})

--- a/test/data/control/ol3_svg.js
+++ b/test/data/control/ol3_svg.js
@@ -19,7 +19,7 @@ var style_airports0 = function(feature, resolution){
                   src: "styles/qgis2web.svg"
             })
     })];
-    var labelText = ""
+    var labelText = "";
     var currentFeature = feature;
     clusteredFeatures = feature.get("features");
     if (typeof clusteredFeatures !== "undefined") {
@@ -42,9 +42,9 @@ var style_airports0 = function(feature, resolution){
         }
     } else {
         if ("" !== null) {
-+           var labelText = String("");
++           labelText = String("");
         } else {
-            var labelText = ""
+            labelText = ""
         }
         var key = value + "_" + labelText
         if (!styleCache_airports0[key]){


### PR DESCRIPTION
Hi Tom, 

I edited the qgis2web.js file to make pupups work for clustered point layers.  On click/hover the clustered points now show information, instead of the [Objects object]. If 3 points are clustered, the popup will show fields that are not set to 'hidden' for all 3 features (I think this makes the most sense, but it can be changed to "please zoom in"). 

To display how many features are clustered and to get rid of the "undefined" upon high zoom-in, I need to change the _style.js files, which are generated through python olStyleScripts.py, exportStyles function (is this right?). I know exactly what needs to be changed in the .js file, but I'm having a hard time testing the olStyleScripts.py file, when I change it within the plugin folder and try to make a qgis2web preview with QGIS desktop, it doesn't recognize my edits. I will try to figure this out over the next few days and then clustering should work well!

Ola