### PR TITLE
Oversized clusters

### DIFF
--- a/olStyleScripts.py
+++ b/olStyleScripts.py
@@ -241,7 +241,7 @@ def getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value)
     var offsetY = 0
     if (size == 1) {
         textAlign = "left"
-        offsetX = 5
+        offsetX = 8
         offsetY = 3
         var feature = clusteredFeatures[0];
         if (%(label)s !== null%(labelRes)s) {
@@ -259,7 +259,7 @@ def getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value)
     else:
         this_style += '''size = 0;
     textAlign = "left"
-    offsetX = 5
+    offsetX = 8
     offsetY = 3
     if (%(label)s !== null%(labelRes)s) {
         labelText = String(%(label)s);

--- a/olStyleScripts.py
+++ b/olStyleScripts.py
@@ -64,17 +64,14 @@ def exportStyles(layers, folder, clustered):
             layer_alpha = layer.layerTransparency()
             if isinstance(renderer, QgsSingleSymbolRendererV2):
                 symbol = renderer.symbol()
-                if cluster:
-                    style = "var size = feature.get('features').length;\n"
-                else:
-                    style = "var size = 0;\n"
-                style += "    var style = " + getSymbolAsStyle(symbol,
-                                                               stylesFolder,
-                                                               layer_alpha,
-                                                               renderer)
+                style = "var style = " + getSymbolAsStyle(symbol,
+                                                          stylesFolder,
+                                                          layer_alpha,
+                                                          renderer)
                 value = 'var value = ""'
             elif isinstance(renderer, QgsCategorizedSymbolRendererV2):
-                defs += """function categories_%s(feature, value) {
+                cluster = False
+                defs += """function categories_%s(feature, value, size) {
                 switch(value) {""" % sln
                 cats = []
                 for cat in renderer.categories():
@@ -98,9 +95,10 @@ def exportStyles(layers, folder, clustered):
                         editorWidget == 'Hidden'):
                     classAttr = "q2wHide_" + classAttr
                 value = ('var value = feature.get("%s");' % classAttr)
-                style = ('''var style = categories_%s(feature, value)''' %
+                style = ('''var style = categories_%s(feature, value, size)''' %
                          (sln))
             elif isinstance(renderer, QgsGraduatedSymbolRendererV2):
+                cluster = False
                 varName = "ranges_" + sln
                 defs += "var %s = [" % varName
                 ranges = []
@@ -127,6 +125,7 @@ def exportStyles(layers, folder, clustered):
         }
     }''' % {"v": varName}
             elif isinstance(renderer, QgsRuleBasedRendererV2):
+                cluster = False
                 template = """
         function rules_%s(feature, value) {
             var context = {
@@ -205,64 +204,7 @@ def exportStyles(layers, folder, clustered):
             else:
                 stroke = ""
             if style != "":
-                style = '''function(feature, resolution){
-    var context = {
-        feature: feature,
-        variables: {}
-    };
-    %(value)s
-    %(style)s;
-    var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!%(cache)s[key]){
-            var text = new ol.style.Text({
-                  font: '%(size)spx \\'%(face)s\\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: '%(color)s'
-                  }),%(stroke)s
-                });
-            %(cache)s[key] = new ol.style.Style({"text": text})
-        }
-    } else {
-        if (%(label)s !== null%(labelRes)s) {
-            labelText = String(%(label)s);
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!%(cache)s[key]){
-            var text = new ol.style.Text({
-                    font: '%(size)spx \\'%(face)s\\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: '%(color)s'
-                    }),%(stroke)s
-                });
-            %(cache)s[key] = new ol.style.Style({"text": text})
-        }
-    }
-    var allStyles = [%(cache)s[key]];
-    allStyles.push.apply(allStyles, style);
-    return allStyles;
-}''' % {
-                    "style": style, "labelRes": labelRes, "label": labelText,
-                    "cache": "styleCache_" + sln,
-                    "size": size, "face": face, "color": color,
-                    "stroke": stroke, "value": value}
+                style = getStyle(style, cluster, labelRes, labelText, sln, size, face, stroke, value)
             else:
                 style = "''"
         except Exception, e:
@@ -278,6 +220,79 @@ def exportStyles(layers, folder, clustered):
 var styleCache_%(name)s={}
 var style_%(name)s = %(style)s;''' %
                     {"defs": defs, "name": sln, "style": style})
+
+
+def getStyle(style, cluster, labelRes, labelText, sln, size, face, stroke, value):
+    this_style = '''function(feature, resolution){
+    var context = {
+        feature: feature,
+        variables: {}
+    };
+    %(value)s
+    var labelText = "";
+    ''' % {
+        "value": value}
+    if cluster:
+        this_style += '''var clusteredFeatures = feature.get("features");
+    size = clusteredFeatures.length;
+    var textAlign = "center"
+    var offsetX = 0
+    var offsetY = 0
+    if (size > 30) {
+        labelText = size.toString()
+        size = 30; 
+    } else if (size <=30 && size >=2){
+        labelText = size.toString()
+    } else {
+        textAlign = "left"
+        offsetX = 5
+        offsetY = 3
+        var feature = feature.get("features")[0];
+        if (%(label)s !== null%(labelRes)s) {
+            labelText = String(%(label)s);
+        } else {
+            labelText = ""
+        }
+        var key = value + "_" + labelText    
+    }
+    %(style)s;''' % {
+            "style": style, "labelRes": labelRes, "label": labelText}
+    else:
+        this_style += '''size = 0;
+    textAlign = "left"
+    offsetX = 5
+    offsetY = 3
+    if (%(label)s !== null%(labelRes)s) {
+        labelText = String(%(label)s);
+    } else {
+        labelText = ""
+    }
+    %(style)s;''' % {
+            "style": style, "labelRes": labelRes, "label": labelText}
+
+    this_style += '''var key = value + "_" + labelText
+    if (!%(cache)s[key]){
+        var text = new ol.style.Text({
+                font: '%(size)spx \\'%(face)s\\', sans-serif',
+                text: labelText,
+                textBaseline: "center",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: '%(stroke)s'
+                })
+            });
+        %(cache)s[key] = new ol.style.Style({"text": text})
+    }
+    var allStyles = [%(cache)s[key]];
+    allStyles.push.apply(allStyles, style);
+    return allStyles;
+    };''' % {
+            "cache": "styleCache_" + sln,
+            "size": size, "face": face,
+            "stroke": stroke}
+    return this_style
 
 
 def getSymbolAsStyle(symbol, stylesFolder, layer_transparency, renderer):
@@ -440,7 +455,7 @@ def getStrokeStyle(color, dashed, width, linecap, linejoin):
 
 def getFillStyle(color, props):
     try:
-        if props["style"] == "no":
+        if props["color"] == "no":
             return ""
     except:
         QgsMessageLog.logMessage(traceback.format_exc(), "qgis2web",

--- a/olStyleScripts.py
+++ b/olStyleScripts.py
@@ -177,14 +177,15 @@ def exportStyles(layers, folder, clustered):
             r = layer.customProperty("labeling/textColorR")
             g = layer.customProperty("labeling/textColorG")
             b = layer.customProperty("labeling/textColorB")
-            color = "rgba(%s, %s, %s, 1)" % (r, g, b)
             if (r or g or b) is None:
                 color = "rgba(0, 0, 0, 1)"
             else:
                 color = "rgba(%s, %s, %s, 1)" % (r, g, b)
             face = layer.customProperty("labeling/fontFamily")
             if face is None:
-                face = "MS Shell Dlg 2"
+                face = ","
+            else:
+                face = " \\'%s\\'," % face
             palyr = QgsPalLayerSettings()
             palyr.readFromLayer(layer)
             sv = palyr.scaleVisibility
@@ -242,9 +243,9 @@ def getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value)
     if cluster:
         this_style += '''var clusteredFeatures = feature.get("features");
     size = clusteredFeatures.length;
-    var textAlign = "center"
-    var offsetX = 0
-    var offsetY = 0
+    var textAlign = "center";
+    var offsetX = 0;
+    var offsetY = 0;
     if (size == 1) {
         textAlign = "left"
         offsetX = 8
@@ -264,9 +265,9 @@ def getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value)
             "style": style, "labelRes": labelRes, "label": labelText}
     else:
         this_style += '''size = 0;
-    textAlign = "left"
-    offsetX = 8
-    offsetY = 3
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
     if (%(label)s !== null%(labelRes)s) {
         labelText = String(%(label)s);
     } else {
@@ -275,10 +276,10 @@ def getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value)
     %(style)s;\n''' % {
             "style": style, "labelRes": labelRes, "label": labelText}
 
-    this_style += '''   key = value + "_" + labelText
+    this_style += '''    key = value + "_" + labelText
     if (!%(cache)s[key]){
         var text = new ol.style.Text({
-                font: '%(size)spx \\'%(face)s\\', sans-serif',
+                font: '%(size)spx%(face)s sans-serif',
                 text: labelText,
                 textBaseline: "middle",
                 textAlign: textAlign,
@@ -293,7 +294,7 @@ def getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value)
     var allStyles = [%(cache)s[key]];
     allStyles.push.apply(allStyles, style);
     return allStyles;
-    }''' % {
+}''' % {
             "cache": "styleCache_" + sln,
             "size": size, "face": face,
             "color": color}

--- a/olStyleScripts.py
+++ b/olStyleScripts.py
@@ -243,7 +243,7 @@ def getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value)
         textAlign = "left"
         offsetX = 5
         offsetY = 3
-        var feature = feature.get("features")[0];
+        var feature = clusteredFeatures[0];
         if (%(label)s !== null%(labelRes)s) {
             labelText = String(%(label)s);
         } else {
@@ -252,7 +252,7 @@ def getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value)
         key = value + "_" + labelText    
     } else {
         labelText = size.toString()
-        size = 2*Math.log(size)
+        size = 2*(Math.log(size)/ Math.log(2))
     }
     %(style)s;\n''' % {
             "style": style, "labelRes": labelRes, "label": labelText}

--- a/olStyleScripts.py
+++ b/olStyleScripts.py
@@ -178,7 +178,13 @@ def exportStyles(layers, folder, clustered):
             g = layer.customProperty("labeling/textColorG")
             b = layer.customProperty("labeling/textColorB")
             color = "rgba(%s, %s, %s, 1)" % (r, g, b)
+            if (r or g or b) is None:
+                color = "rgba(0, 0, 0, 1)"
+            else:
+                color = "rgba(%s, %s, %s, 1)" % (r, g, b)
             face = layer.customProperty("labeling/fontFamily")
+            if face is None:
+                face = "MS Shell Dlg 2"
             palyr = QgsPalLayerSettings()
             palyr.readFromLayer(layer)
             sv = palyr.scaleVisibility
@@ -287,7 +293,7 @@ def getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value)
     var allStyles = [%(cache)s[key]];
     allStyles.push.apply(allStyles, style);
     return allStyles;
-    };''' % {
+    }''' % {
             "cache": "styleCache_" + sln,
             "size": size, "face": face,
             "color": color}

--- a/olStyleScripts.py
+++ b/olStyleScripts.py
@@ -95,8 +95,8 @@ def exportStyles(layers, folder, clustered):
                         editorWidget == 'Hidden'):
                     classAttr = "q2wHide_" + classAttr
                 value = ('var value = feature.get("%s");' % classAttr)
-                style = ('''var style = categories_%s(feature, value, size)''' %
-                         (sln))
+                style = (
+                    'var style = categories_%s(feature, value, size)' % sln)
             elif isinstance(renderer, QgsGraduatedSymbolRendererV2):
                 cluster = False
                 varName = "ranges_" + sln
@@ -211,7 +211,8 @@ def exportStyles(layers, folder, clustered):
             else:
                 stroke = ""
             if style != "":
-                style = getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value)
+                style = getStyle(style, cluster, labelRes, labelText,
+                                 sln, size, face, color, value)
             else:
                 style = "''"
         except Exception, e:
@@ -229,7 +230,8 @@ var style_%(name)s = %(style)s;''' %
                     {"defs": defs, "name": sln, "style": style})
 
 
-def getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value):
+def getStyle(style, cluster, labelRes, labelText,
+             sln, size, face, color, value):
     this_style = '''function(feature, resolution){
     var context = {
         feature: feature,
@@ -256,7 +258,7 @@ def getStyle(style, cluster, labelRes, labelText, sln, size, face, color, value)
         } else {
             labelText = ""
         }
-        key = value + "_" + labelText    
+        key = value + "_" + labelText
     } else {
         labelText = size.toString()
         size = 2*(Math.log(size)/ Math.log(2))

--- a/test/data/control/ol3_json_line_categorized.html
+++ b/test/data/control/ol3_json_line_categorized.html
@@ -78,7 +78,7 @@ var style_pipelines0 = function(feature, resolution){
         labelText = ""
     }
     var style = categories_pipelines0(feature, value, size);
-    var key = value + "_" + labelText
+    key = value + "_" + labelText
     if (!styleCache_pipelines0[key]){
         var text = new ol.style.Text({
                 font: '10.725px \'MS Shell Dlg 2\', sans-serif',
@@ -89,7 +89,7 @@ var style_pipelines0 = function(feature, resolution){
                 offsetY: offsetY,
                 fill: new ol.style.Fill({
                   color: 'rgba(0, 0, 0, 1)'
-                }),
+                })
             });
         styleCache_pipelines0[key] = new ol.style.Style({"text": text})
     }

--- a/test/data/control/ol3_json_line_categorized.html
+++ b/test/data/control/ol3_json_line_categorized.html
@@ -43,7 +43,7 @@
     </body>
 </html>
 var size = 0;
-function categories_pipelines0(feature, value) {
+function categories_pipelines0(feature, value, size) {
                 switch(value) {case 'Below Surface/Submerged/Underground':
                     return [ new ol.style.Style({
         stroke: new ol.style.Stroke({color: 'rgba(161,121,229,1.0)', lineDash: null, lineCap: 'square', lineJoin: 'bevel', width: 0}),
@@ -66,49 +66,32 @@ var style_pipelines0 = function(feature, resolution){
         variables: {}
     };
     var value = feature.get("LOCDESC");
-    var style = categories_pipelines0(feature, value);
     var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_pipelines0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
-        }
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if ("" !== null) {
+        labelText = String("");
     } else {
-        if ("" !== null) {
-            labelText = String("");
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_pipelines0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
-        }
+        labelText = ""
+    }
+    var style = categories_pipelines0(feature, value, size);
+    key = value + "_" + labelText
+    if (!styleCache_pipelines0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_pipelines0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_pipelines0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_line_graduated.html
+++ b/test/data/control/ol3_json_line_graduated.html
@@ -65,6 +65,17 @@ var style_pipelines0 = function(feature, resolution){
         variables: {}
     };
     var value = feature.get("cat");
+    var labelText = "";
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if ("" !== null) {
+        labelText = String("");
+    } else {
+        labelText = ""
+    }
     var style = ranges_pipelines0[0][2];
     for (i = 0; i < ranges_pipelines0.length; i++){
         var range = ranges_pipelines0[i];
@@ -72,48 +83,20 @@ var style_pipelines0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_pipelines0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
-        }
-    } else {
-        if ("" !== null) {
-            labelText = String("");
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_pipelines0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
-        }
+    key = value + "_" + labelText
+    if (!styleCache_pipelines0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_pipelines0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_pipelines0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_line_graduated.html
+++ b/test/data/control/ol3_json_line_graduated.html
@@ -83,7 +83,7 @@ var style_pipelines0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    var key = value + "_" + labelText
+    key = value + "_" + labelText
     if (!styleCache_pipelines0[key]){
         var text = new ol.style.Text({
                 font: '10.725px \'MS Shell Dlg 2\', sans-serif',
@@ -94,7 +94,7 @@ var style_pipelines0 = function(feature, resolution){
                 offsetY: offsetY,
                 fill: new ol.style.Fill({
                   color: 'rgba(0, 0, 0, 1)'
-                }),
+                })
             });
         styleCache_pipelines0[key] = new ol.style.Style({"text": text})
     }

--- a/test/data/control/ol3_json_line_single.html
+++ b/test/data/control/ol3_json_line_single.html
@@ -65,7 +65,7 @@ var style_pipelines0 = function(feature, resolution){
     var style = [ new ol.style.Style({
         stroke: new ol.style.Stroke({color: 'rgba(242,66,72,1.0)', lineDash: null, lineCap: 'square', lineJoin: 'bevel', width: 0}),
     })];
-    var key = value + "_" + labelText
+    key = value + "_" + labelText
     if (!styleCache_pipelines0[key]){
         var text = new ol.style.Text({
                 font: '10.725px \'MS Shell Dlg 2\', sans-serif',
@@ -76,7 +76,7 @@ var style_pipelines0 = function(feature, resolution){
                 offsetY: offsetY,
                 fill: new ol.style.Fill({
                   color: 'rgba(0, 0, 0, 1)'
-                }),
+                })
             });
         styleCache_pipelines0[key] = new ol.style.Style({"text": text})
     }

--- a/test/data/control/ol3_json_line_single.html
+++ b/test/data/control/ol3_json_line_single.html
@@ -51,52 +51,34 @@ var style_pipelines0 = function(feature, resolution){
         variables: {}
     };
     var value = ""
-    var size = 0;
+    var labelText = "";
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if ("" !== null) {
+        labelText = String("");
+    } else {
+        labelText = ""
+    }
     var style = [ new ol.style.Style({
         stroke: new ol.style.Stroke({color: 'rgba(242,66,72,1.0)', lineDash: null, lineCap: 'square', lineJoin: 'bevel', width: 0}),
     })];
-    var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_pipelines0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
-        }
-    } else {
-        if ("" !== null) {
-            labelText = String("");
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_pipelines0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_pipelines0[key] = new ol.style.Style({"text": text})
-        }
+    key = value + "_" + labelText
+    if (!styleCache_pipelines0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_pipelines0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_pipelines0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_point_categorized.html
+++ b/test/data/control/ol3_json_point_categorized.html
@@ -75,7 +75,7 @@ default:
     })];
                     break;}};
 var styleCache_airports0={}
-var style_airports0 = function(feature, resolution, size){
+var style_airports0 = function(feature, resolution){
     var context = {
         feature: feature,
         variables: {}
@@ -93,7 +93,7 @@ var style_airports0 = function(feature, resolution, size){
         labelText = ""
     }
     var style = categories_airports0(feature, value, size);
-    var key = value + "_" + labelText
+    key = value + "_" + labelText
     if (!styleCache_airports0[key]){
         var text = new ol.style.Text({
                 font: '10.725px \'MS Shell Dlg 2\', sans-serif',
@@ -104,7 +104,7 @@ var style_airports0 = function(feature, resolution, size){
                 offsetY: offsetY,
                 fill: new ol.style.Fill({
                   color: 'rgba(0, 0, 0, 1)'
-                }),
+                })
             });
         styleCache_airports0[key] = new ol.style.Style({"text": text})
     }

--- a/test/data/control/ol3_json_point_categorized.html
+++ b/test/data/control/ol3_json_point_categorized.html
@@ -43,7 +43,7 @@
     </body>
 </html>
 var size = 0;
-function categories_airports0(feature, value) {
+function categories_airports0(feature, value, size) {
                 switch(value) {case 'Civilian/Public':
                     return [ new ol.style.Style({
         image: new ol.style.Circle({radius: 4.0 + size,
@@ -81,49 +81,32 @@ var style_airports0 = function(feature, resolution){
         variables: {}
     };
     var value = feature.get("USE");
-    var style = categories_airports0(feature, value);
     var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if ("" !== null) {
+        labelText = String("");
     } else {
-        if ("" !== null) {
-            labelText = String("");
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
+        labelText = ""
+    }
+    var style = categories_airports0(feature, value, size);
+    key = value + "_" + labelText
+    if (!styleCache_airports0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_airports0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_point_graduated.html
+++ b/test/data/control/ol3_json_point_graduated.html
@@ -88,7 +88,7 @@ var style_airports0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    var key = value + "_" + labelText
+    key = value + "_" + labelText
     if (!styleCache_airports0[key]){
         var text = new ol.style.Text({
                 font: '10.725px \'MS Shell Dlg 2\', sans-serif',
@@ -99,7 +99,7 @@ var style_airports0 = function(feature, resolution){
                 offsetY: offsetY,
                 fill: new ol.style.Fill({
                   color: 'rgba(0, 0, 0, 1)'
-                }),
+                })
             });
         styleCache_airports0[key] = new ol.style.Style({"text": text})
     }

--- a/test/data/control/ol3_json_point_graduated.html
+++ b/test/data/control/ol3_json_point_graduated.html
@@ -70,6 +70,17 @@ var style_airports0 = function(feature, resolution){
         variables: {}
     };
     var value = feature.get("ELEV");
+    var labelText = "";
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if ("" !== null) {
+        labelText = String("");
+    } else {
+        labelText = ""
+    }
     var style = ranges_airports0[0][2];
     for (i = 0; i < ranges_airports0.length; i++){
         var range = ranges_airports0[i];
@@ -77,48 +88,20 @@ var style_airports0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
-    } else {
-        if ("" !== null) {
-            labelText = String("");
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
+    key = value + "_" + labelText
+    if (!styleCache_airports0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_airports0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_point_single.html
+++ b/test/data/control/ol3_json_point_single.html
@@ -51,53 +51,35 @@ var style_airports0 = function(feature, resolution){
         variables: {}
     };
     var value = ""
-    var size = 0;
+    var labelText = "";
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if ("" !== null) {
+        labelText = String("");
+    } else {
+        labelText = ""
+    }
     var style = [ new ol.style.Style({
         image: new ol.style.Circle({radius: 4.0 + size,
             stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(39,147,25,1.0)'})})
     })];
-    var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
-    } else {
-        if ("" !== null) {
-            labelText = String("");
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
+    key = value + "_" + labelText
+    if (!styleCache_airports0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_airports0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_point_single.html
+++ b/test/data/control/ol3_json_point_single.html
@@ -66,7 +66,7 @@ var style_airports0 = function(feature, resolution){
         image: new ol.style.Circle({radius: 4.0 + size,
             stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(39,147,25,1.0)'})})
     })];
-    var key = value + "_" + labelText
+    key = value + "_" + labelText
     if (!styleCache_airports0[key]){
         var text = new ol.style.Text({
                 font: '10.725px \'MS Shell Dlg 2\', sans-serif',
@@ -77,7 +77,7 @@ var style_airports0 = function(feature, resolution){
                 offsetY: offsetY,
                 fill: new ol.style.Fill({
                   color: 'rgba(0, 0, 0, 1)'
-                }),
+                })
             });
         styleCache_airports0[key] = new ol.style.Style({"text": text})
     }

--- a/test/data/control/ol3_json_polygon_categorized.html
+++ b/test/data/control/ol3_json_polygon_categorized.html
@@ -43,7 +43,7 @@
     </body>
 </html>
 var size = 0;
-function categories_lakes0(feature, value) {
+function categories_lakes0(feature, value, size) {
                 switch(value) {case 'Becharof Lake':
                     return [ new ol.style.Style({
         stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(89,109,204,1.0)'})
@@ -131,49 +131,32 @@ var style_lakes0 = function(feature, resolution){
         variables: {}
     };
     var value = feature.get("NAMES");
-    var style = categories_lakes0(feature, value);
     var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_lakes0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_lakes0[key] = new ol.style.Style({"text": text})
-        }
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if ("" !== null) {
+        labelText = String("");
     } else {
-        if ("" !== null) {
-            labelText = String("");
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_lakes0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_lakes0[key] = new ol.style.Style({"text": text})
-        }
+        labelText = ""
+    }
+    var style = categories_lakes0(feature, value, size);
+    key = value + "_" + labelText
+    if (!styleCache_lakes0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_lakes0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_lakes0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_polygon_categorized.html
+++ b/test/data/control/ol3_json_polygon_categorized.html
@@ -143,7 +143,7 @@ var style_lakes0 = function(feature, resolution){
         labelText = ""
     }
     var style = categories_lakes0(feature, value, size);
-    var key = value + "_" + labelText
+    key = value + "_" + labelText
     if (!styleCache_lakes0[key]){
         var text = new ol.style.Text({
                 font: '10.725px \'MS Shell Dlg 2\', sans-serif',
@@ -154,7 +154,7 @@ var style_lakes0 = function(feature, resolution){
                 offsetY: offsetY,
                 fill: new ol.style.Fill({
                   color: 'rgba(0, 0, 0, 1)'
-                }),
+                })
             });
         styleCache_lakes0[key] = new ol.style.Style({"text": text})
     }

--- a/test/data/control/ol3_json_polygon_graduated.html
+++ b/test/data/control/ol3_json_polygon_graduated.html
@@ -65,6 +65,17 @@ var style_lakes0 = function(feature, resolution){
         variables: {}
     };
     var value = feature.get("AREA_MI");
+    var labelText = "";
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if ("" !== null) {
+        labelText = String("");
+    } else {
+        labelText = ""
+    }
     var style = ranges_lakes0[0][2];
     for (i = 0; i < ranges_lakes0.length; i++){
         var range = ranges_lakes0[i];
@@ -72,48 +83,20 @@ var style_lakes0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_lakes0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_lakes0[key] = new ol.style.Style({"text": text})
-        }
-    } else {
-        if ("" !== null) {
-            labelText = String("");
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_lakes0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_lakes0[key] = new ol.style.Style({"text": text})
-        }
+    key = value + "_" + labelText
+    if (!styleCache_lakes0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_lakes0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_lakes0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_json_polygon_graduated.html
+++ b/test/data/control/ol3_json_polygon_graduated.html
@@ -83,7 +83,7 @@ var style_lakes0 = function(feature, resolution){
             style =  range[2];
         }
     };
-    var key = value + "_" + labelText
+    key = value + "_" + labelText
     if (!styleCache_lakes0[key]){
         var text = new ol.style.Text({
                 font: '10.725px \'MS Shell Dlg 2\', sans-serif',
@@ -94,7 +94,7 @@ var style_lakes0 = function(feature, resolution){
                 offsetY: offsetY,
                 fill: new ol.style.Fill({
                   color: 'rgba(0, 0, 0, 1)'
-                }),
+                })
             });
         styleCache_lakes0[key] = new ol.style.Style({"text": text})
     }

--- a/test/data/control/ol3_json_polygon_single.html
+++ b/test/data/control/ol3_json_polygon_single.html
@@ -65,7 +65,7 @@ var style_lakes0 = function(feature, resolution){
     var style = [ new ol.style.Style({
         stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(56,204,206,1.0)'})
     })];
-    var key = value + "_" + labelText
+    key = value + "_" + labelText
     if (!styleCache_lakes0[key]){
         var text = new ol.style.Text({
                 font: '10.725px \'MS Shell Dlg 2\', sans-serif',
@@ -76,7 +76,7 @@ var style_lakes0 = function(feature, resolution){
                 offsetY: offsetY,
                 fill: new ol.style.Fill({
                   color: 'rgba(0, 0, 0, 1)'
-                }),
+                })
             });
         styleCache_lakes0[key] = new ol.style.Style({"text": text})
     }

--- a/test/data/control/ol3_json_polygon_single.html
+++ b/test/data/control/ol3_json_polygon_single.html
@@ -51,52 +51,34 @@ var style_lakes0 = function(feature, resolution){
         variables: {}
     };
     var value = ""
-    var size = 0;
+    var labelText = "";
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if ("" !== null) {
+        labelText = String("");
+    } else {
+        labelText = ""
+    }
     var style = [ new ol.style.Style({
         stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(56,204,206,1.0)'})
     })];
-    var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_lakes0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_lakes0[key] = new ol.style.Style({"text": text})
-        }
-    } else {
-        if ("" !== null) {
-            labelText = String("");
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_lakes0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_lakes0[key] = new ol.style.Style({"text": text})
-        }
+    key = value + "_" + labelText
+    if (!styleCache_lakes0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_lakes0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_lakes0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_labels.js
+++ b/test/data/control/ol3_labels.js
@@ -22,7 +22,7 @@ var style_airports0 = function(feature, resolution){
         image: new ol.style.Circle({radius: 4.0 + size,
             stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(39,147,25,1.0)'})})
     })];
-    var key = value + "_" + labelText
+    key = value + "_" + labelText
     if (!styleCache_airports0[key]){
         var text = new ol.style.Text({
                 font: '10.725px \'MS Shell Dlg 2\', sans-serif',
@@ -33,7 +33,7 @@ var style_airports0 = function(feature, resolution){
                 offsetY: offsetY,
                 fill: new ol.style.Fill({
                   color: 'rgba(0, 0, 0, 1)'
-                }),
+                })
             });
         styleCache_airports0[key] = new ol.style.Style({"text": text})
     }

--- a/test/data/control/ol3_labels.js
+++ b/test/data/control/ol3_labels.js
@@ -7,53 +7,35 @@ var style_airports0 = function(feature, resolution){
         variables: {}
     };
     var value = ""
-    var size = 0;
+    var labelText = "";
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if (feature.get("NAME") !== null) {
+        labelText = String(feature.get("NAME"));
+    } else {
+        labelText = ""
+    }
     var style = [ new ol.style.Style({
         image: new ol.style.Circle({radius: 4.0 + size,
             stroke: new ol.style.Stroke({color: 'rgba(0,0,0,1.0)', lineDash: null, lineCap: 'butt', lineJoin: 'miter', width: 0}), fill: new ol.style.Fill({color: 'rgba(39,147,25,1.0)'})})
     })];
-    var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
-    } else {
-        if (feature.get("NAME") !== null) {
-            labelText = String(feature.get("NAME"));
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
+    key = value + "_" + labelText
+    if (!styleCache_airports0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_airports0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_rule-based.js
+++ b/test/data/control/ol3_rule-based.js
@@ -40,7 +40,7 @@ var style_airports0 = function(feature, resolution){
         }
         var style = rules_airports0(feature, value);
         ;
-    var key = value + "_" + labelText
+    key = value + "_" + labelText
     if (!styleCache_airports0[key]){
         var text = new ol.style.Text({
                 font: '10.725px \'MS Shell Dlg 2\', sans-serif',
@@ -51,7 +51,7 @@ var style_airports0 = function(feature, resolution){
                 offsetY: offsetY,
                 fill: new ol.style.Fill({
                   color: 'rgba(0, 0, 0, 1)'
-                }),
+                })
             });
         styleCache_airports0[key] = new ol.style.Style({"text": text})
     }

--- a/test/data/control/ol3_rule-based.js
+++ b/test/data/control/ol3_rule-based.js
@@ -7,6 +7,17 @@ var style_airports0 = function(feature, resolution){
         variables: {}
     };
     var value = '';
+    var labelText = "";
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if ("" !== null) {
+        labelText = String("");
+    } else {
+        labelText = ""
+    }
     
         function rules_airports0(feature, value) {
             var context = {
@@ -29,48 +40,20 @@ var style_airports0 = function(feature, resolution){
         }
         var style = rules_airports0(feature, value);
         ;
-    var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
-    } else {
-        if ("" !== null) {
-            labelText = String("");
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
+    key = value + "_" + labelText
+    if (!styleCache_airports0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_airports0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);

--- a/test/data/control/ol3_svg.js
+++ b/test/data/control/ol3_svg.js
@@ -29,21 +29,21 @@ var style_airports0 = function(feature, resolution){
                   src: "styles/qgis2web.svg"
             })
     })];
-      var key = value + "_" + labelText
-      if (!styleCache_airports0[key]){
-          var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textBaseline: "middle",
-                  textAlign: textAlign,
-                  offsetX: offsetX,
-                  offsetY: offsetY,
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-              });
-          styleCache_airports0[key] = new ol.style.Style({"text": text})
-      }
+    key = value + "_" + labelText
+    if (!styleCache_airports0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_airports0[key] = new ol.style.Style({"text": text})
+    }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);
     return allStyles;

--- a/test/data/control/ol3_svg.js
+++ b/test/data/control/ol3_svg.js
@@ -7,7 +7,17 @@ var style_airports0 = function(feature, resolution){
         variables: {}
     };
     var value = ""
-    var size = 0;
+    var labelText = "";
+    var key = "";
+    size = 0;
+    var textAlign = "left";
+    var offsetX = 8;
+    var offsetY = 3;
+    if ("" !== null) {
+        labelText = String("");
+    } else {
+        labelText = ""
+    }
     var style = [ new ol.style.Style({
         image: new ol.style.Icon({
                   imgSize: [100, 100],
@@ -19,48 +29,20 @@ var style_airports0 = function(feature, resolution){
                   src: "styles/qgis2web.svg"
             })
     })];
-    var labelText = "";
-    var currentFeature = feature;
-    clusteredFeatures = feature.get("features");
-    if (typeof clusteredFeatures !== "undefined") {
-        if (size >= 2) {
-            labelText = size.toString()
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                  font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                  text: labelText,
-                  textAlign: "center",
-                  fill: new ol.style.Fill({
-                    color: 'rgba(0, 0, 0, 1)'
-                  }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
-    } else {
-        if ("" !== null) {
-            labelText = String("");
-        } else {
-            labelText = ""
-        }
-        var key = value + "_" + labelText
-        if (!styleCache_airports0[key]){
-            var text = new ol.style.Text({
-                    font: '10.725px \'MS Shell Dlg 2\', sans-serif',
-                    text: labelText,
-                    textBaseline: "center",
-                    textAlign: "left",
-                    offsetX: 5,
-                    offsetY: 3,
-                    fill: new ol.style.Fill({
-                      color: 'rgba(0, 0, 0, 1)'
-                    }),
-                });
-            styleCache_airports0[key] = new ol.style.Style({"text": text})
-        }
+    key = value + "_" + labelText
+    if (!styleCache_airports0[key]){
+        var text = new ol.style.Text({
+                font: '10.725px \'MS Shell Dlg 2\', sans-serif',
+                text: labelText,
+                textBaseline: "middle",
+                textAlign: textAlign,
+                offsetX: offsetX,
+                offsetY: offsetY,
+                fill: new ol.style.Fill({
+                  color: 'rgba(0, 0, 0, 1)'
+                })
+            });
+        styleCache_airports0[key] = new ol.style.Style({"text": text})
     }
     var allStyles = [styleCache_airports0[key]];
     allStyles.push.apply(allStyles, style);


### PR DESCRIPTION
Hi Tom,

I made few changes to the `olStyleScripts.py` to fix the following:

- Oversize cluster issue – clustering is now restricted to `30px`.
- Labels did not show up for a single data point within a clustered layer – this is now fixed.

The `olStyleScripts.py` now generates different `_style.js` files, based on if the layer is clustered or not. It seemed to make more sense to check if the layer is clustered on the backend. 

Please note that categorized, graduated or rule based layers are currently not set to cluster. For example, in the `olLayerScripts.py` file, only single symbol layers are included:
```
if (cluster and isinstance(renderer, QgsSingleSymbolRendererV2)):
    cluster = True
```
I noticed an error in on `Line 458` where `if props["style"] == "no":`  was showing me  `KeyError: 'style'`, I changed this to `props["color"] == "no":`

Please check it over and let me know if anything needs to be changed!

![clusters](https://cloud.githubusercontent.com/assets/28122345/26748059/b4fe3b9c-47b7-11e7-84ce-19fb92de8ceb.png)

