### PR TITLE
XYZ tile layer zoom parameters.

### DIFF
--- a/qgis2web/leafletScriptStrings.py
+++ b/qgis2web/leafletScriptStrings.py
@@ -286,7 +286,8 @@ def clusterScript(safeLayerName):
     return cluster
 
 
-def wmsScript(layer, safeLayerName, useWMS, useWMTS, identify, minZoom, maxZoom):
+def wmsScript(layer, safeLayerName, useWMS, useWMTS, identify, minZoom,
+              maxZoom):
     d = parse_qs(layer.source())
     opacity = layer.renderer().opacity()
     attr = ""

--- a/qgis2web/leafletScriptStrings.py
+++ b/qgis2web/leafletScriptStrings.py
@@ -286,7 +286,7 @@ def clusterScript(safeLayerName):
     return cluster
 
 
-def wmsScript(layer, safeLayerName, useWMS, useWMTS, identify):
+def wmsScript(layer, safeLayerName, useWMS, useWMTS, identify, minZoom, maxZoom):
     d = parse_qs(layer.source())
     opacity = layer.renderer().opacity()
     attr = ""
@@ -299,10 +299,15 @@ def wmsScript(layer, safeLayerName, useWMS, useWMTS, identify):
         var layer_{safeLayerName} = L.tileLayer('{url}', {{
             opacity: {opacity},
             attribution: '{attr}',
+            minZoom: {minZoom},
+            maxZoom: {maxZoom},
+            minNativeZoom: {minNativeZoom},
+            maxNativeZoom: {maxNativeZoom}
         }});
         layer_{safeLayerName};""".format(
             opacity=opacity, safeLayerName=safeLayerName, url=d['url'][0],
-            attr=attr)
+            attr=attr, minNativeZoom=d['zmin'][0], maxNativeZoom=d['zmax'][0],
+            minZoom=minZoom, maxZoom=maxZoom)
     elif 'tileMatrixSet' in d:
         useWMTS = True
         wmts_url = d['url'][0]
@@ -423,10 +428,10 @@ def titleSubScript(webmap_head, level, pos):
                 abstract.show = function () {
                     this._div.classList.remove("abstract");
                     this._div.classList.add("abstractUncollapsed");
-                    this._div.innerHTML = '""" 
+                    this._div.innerHTML = '"""
         else:
             titleSub += """
-                    
+
                     abstract.show();
                     return this._div;
                 };
@@ -434,7 +439,7 @@ def titleSubScript(webmap_head, level, pos):
                     this._div.classList.remove("abstract");
                     this._div.classList.add("abstractUncollapsed");
                     this._div.innerHTML = '"""
-            
+
         titleSub += webmap_head.replace("'", "\\'").replace("\n", "<br />")
         titleSub += """';
             };

--- a/qgis2web/leafletWriter.py
+++ b/qgis2web/leafletWriter.py
@@ -278,7 +278,8 @@ class LeafletWriter(Writer):
                                           layer.name())
                     new_obj, useWMS, useWMTS = wmsScript(layer, safeLayerName,
                                                          useWMS, useWMTS,
-                                                         getFeatureInfo[count])
+                                                         getFeatureInfo[count],
+                                                         minZoom, maxZoom)
                     feedback.completeStep()
                 else:
                     useRaster = True


### PR DESCRIPTION
Came across this plugin last week and it is amazing :smiley: I wish I had known about it earlier!

One issue however I came across after exporting an xyz layer was that the set zoom parameters weren't being respected. This resulted in the layer not being rendered in the browser once the zoom level was greater than 18 (the default in Leaflet).

This pull request passes the zoom parameters into Leaflet which results in the layer being viewed as it is in QGIS.

This is my first pull request for this project so please any feedback is welcome :+1: 