### PR TITLE
catch IndexErrors when accessing symbol layers during test for 2.5D

### DIFF
--- a/qgis2web/utils.py
+++ b/qgis2web/utils.py
@@ -504,11 +504,16 @@ def is25d(layer, canvas, restrictToExtent, extent):
             symbols.append(symbol)
         renderer.stopRender(renderContext)
     for sym in symbols:
-        sl1 = sym.symbolLayer(1)
-        sl2 = sym.symbolLayer(2)
+        try:
+            sl1 = sym.symbolLayer(1)
+            sl2 = sym.symbolLayer(2)
+        except IndexError:
+            return False
+
         if (isinstance(sl1, QgsGeometryGeneratorSymbolLayer) and
                 isinstance(sl2, QgsGeometryGeneratorSymbolLayer)):
             return True
+
     return False
 
 


### PR DESCRIPTION
qgis/QGIS@ac0326a3517263cc2b9311aa01aeb2c5453ce21b added IndexErrors when
accessing non-existent symbolLayers, which broke some of the exporters/tests.

This should fix that.

refs #812 