### PR TITLE
Format wms getfeature info request for leaflet

### DIFF
--- a/qgis2web/js/leaflet.wms.js
+++ b/qgis2web/js/leaflet.wms.js
@@ -207,7 +207,82 @@ wms.Source = L.Layer.extend({
             // Try loading content in <iframe>.
             result = "<iframe src='" + url + "' style='border:none'>";
         }
-        return result;
+
+        const response = result
+
+        //parseWMSResponse(response)
+        // parse the wms response
+        const el = document.createElement('html');
+        el.innerHTML = response
+
+        const keys = []
+        el.querySelectorAll('th').forEach((th) => {
+            keys.push(th.innerText)
+        })
+
+        const values = []
+        el.querySelectorAll('td').forEach((td) => {
+            values.push(td.innerText)
+        })
+
+        // get the keys and the values
+
+
+        // create new html response
+
+        const html = document.createElement('html')
+        const head = document.createElement('head')
+        const body = document.createElement('body')
+        const table = document.createElement('table')
+
+        table.classList.add('featureInfo')
+
+        for (i = 0; i < keys.length; i++) {
+            const tr = document.createElement('tr')
+            const tdKey = document.createElement('td')
+            tdKey.classList.add('featureKey')
+            const tdValue = document.createElement('td')
+            tdValue.classList.add('featureValue')
+
+            tdKey.innerHTML = keys[i]
+            tdValue.innerHTML = values[i]
+
+            tr.appendChild(tdKey)
+            tr.appendChild(tdValue)
+
+            table.appendChild(tr)
+        }
+        const style = document.createElement('style')
+        style.type = 'text/css'
+        css = document.createTextNode(`
+        table.featureInfo, table.featureInfo td {
+            border: 1px solid black;
+        }
+        
+        td.featureKey {
+            font-weight: bold;
+        }
+        
+        td.featureValue {
+        
+        }
+        `
+        )
+
+        style.appendChild(css)
+        head.appendChild(style)
+
+
+        html.appendChild(head)
+
+        body.appendChild(table)
+
+        html.appendChild(body)
+
+
+
+        return html;
+
     },
 
     'showFeatureInfo': function(latlng, info) {


### PR DESCRIPTION
# Problem

The current implementation for wms get feature response doesn't get formatted properly.
![unformated](https://user-images.githubusercontent.com/2510900/77145758-1d71fb00-6a92-11ea-8eac-e55a44374d39.png)

In GeoServer you could format this using get feature info templates for many users this might be time-consuming.

This fix will format the response to something like below
![get-feature](https://user-images.githubusercontent.com/2510900/77145856-5ad68880-6a92-11ea-9b8a-0e1ff6a42436.png)
