### PR TITLE
Add prefix to safeName() to avoid naming that start with underscore on export

### DIFF
--- a/qgis2web/utils.py
+++ b/qgis2web/utils.py
@@ -524,7 +524,7 @@ def safeName(name):
     # TODO: we are assuming that at least one character is valid...
     validChr = '_0123456789abcdefghijklmnopqrstuvwxyz' \
                'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-    return ''.join(c for c in name if c in validChr)
+    return 'l_' + ''.join(c for c in name if c in validChr)
 
 
 def removeSpaces(txt):


### PR DESCRIPTION
There is a problem with cyrillic layer names. Plugin exports them as numbers prefixed with underscores — that works perfectly fine on local machine, but if we try to host generated web-map on Github, these files become unaccessible, returning "404" error.

I noticed that adding a letter to the beginning of filenames solves the problem. So, I suggest one minor change in function `safeName(name)` to add these prefix.