### PR TITLE
Add symlinks on install of QtWebEngine to locate the Qt Frameworks for preview on macOS

### DIFF
--- a/maindialog.py
+++ b/maindialog.py
@@ -1487,7 +1487,7 @@ def install_qtwebengine():
 
             try:
                 framework_directory_listing = os.listdir(framework_path)
-            except FileNotFoundError as e:
+            except FileNotFoundError:
                 raise FileNotFoundError(
                     "Unable to locate framework directory for QGIS. Only app bundles are supported " + 
                     "e.g., the official QGIS version. Path searched: %s" % framework_path


### PR DESCRIPTION
On an M1 Mac, the current qgis2web release 3.26, and QGIS 3.40, the code noted in #1094 installed QtWebEngine, but it wouldn't show the preview.

Where the preview should be, it briefly flashed white after pressing Update Preview.

Running QGIS from a terminal it could be seen that the dynamic loader (dyld) output and it was unable to find the other Qt frameworks.

This fixes the issue by adding symlinks to the Frameworks so that PyQtWebEngine can find the rest of Qt. This is due to the QtWebEngine executable RPATH being set to `@rpath/QtGui.framework/Versions/5/QtGui`
