### PR TITLE
Handle capitalisation of true false in QGIS Expression to Javascript conversion

### DIFF
--- a/exp2js.py
+++ b/exp2js.py
@@ -183,10 +183,14 @@ def handle_in(node, mapLib):
 
 
 def handle_literal(node):
+    # JavaScript expects the capitalisation for
+    # reserved words to be lowercase
     val = node.value()
     quote = ""
     if val is None:
         val = "null"
+    elif isinstance(val, bool):
+        val = "true" if val == True else "false"
     elif isinstance(val, str):
         quote = "'"
         val = val.replace("\n", "\\n")


### PR DESCRIPTION
Resolves the issue from #1155

Ensures true and false are capitalised properly for Javascript.